### PR TITLE
fixing attempt to issues 22 to 26

### DIFF
--- a/src/masm/model/base.py
+++ b/src/masm/model/base.py
@@ -60,6 +60,9 @@ class ModelObject:
     context: JsonMap = field(default_factory=dict)
     provenance: JsonMap = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        """Terminal hook for the cooperative __post_init__ chain."""
+
     def add_relation(self, name: str, target_id: ObjectId) -> None:
         """Add a relation to another object."""
         self._manage_relation(name, target_id, add=True)

--- a/src/masm/model/objects.py
+++ b/src/masm/model/objects.py
@@ -18,6 +18,7 @@ class GenericObject(ModelObject):
     """
 
     def __post_init__(self) -> None:
+        super().__post_init__()
         if not self.id:
             raise ValueError("Object id cannot be empty")
 

--- a/src/masm/model/objects.py
+++ b/src/masm/model/objects.py
@@ -18,7 +18,8 @@ class GenericObject(ModelObject):
     """
 
     def __post_init__(self) -> None:
-        pass
+        if not self.id:
+            raise ValueError("Object id cannot be empty")
 
     @property
     def label(self) -> Optional[str]:

--- a/src/masm/model/perception.py
+++ b/src/masm/model/perception.py
@@ -167,6 +167,14 @@ class Perception:
     context: JsonMap = field(default_factory=dict)
     provenance: JsonMap = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        if self.timestamp is not None and not isinstance(
+            self.timestamp, (int, float, str)
+        ):
+            raise TypeError(
+                f"timestamp must be int, float, or str, got {type(self.timestamp).__name__}"
+            )
+
     # --- Query API ----------------------------------------------------------
 
     def get_perceived_space(self, space_id: SpaceId) -> Optional[PerceivedSpace]:

--- a/src/masm/model/perception.py
+++ b/src/masm/model/perception.py
@@ -216,9 +216,27 @@ class Perception:
                 for space_id, ps in sorted(self.perceived_spaces.items())
             },
             "perceived_memberships": [
-                pm.to_dict() for pm in self.perceived_memberships
+                pm.to_dict()
+                for pm in sorted(
+                    self.perceived_memberships,
+                    key=lambda x: (
+                        x.membership.space_id,
+                        x.membership.object_id,
+                        x.membership.role,
+                    ),
+                )
             ],
-            "perceived_relations": [pr.to_dict() for pr in self.perceived_relations],
+            "perceived_relations": [
+                pr.to_dict()
+                for pr in sorted(
+                    self.perceived_relations,
+                    key=lambda x: (
+                        x.relation.source_space_id,
+                        x.relation.target_space_id,
+                        x.relation.relation_type,
+                    ),
+                )
+            ],
             "context": dict(sorted(self.context.items())),
             "provenance": dict(sorted(self.provenance.items())),
         }

--- a/src/masm/model/perception.py
+++ b/src/masm/model/perception.py
@@ -19,7 +19,7 @@ Each perceived element carries:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from .spaces import Space, SpaceObjectMembership
 from .space_relations import SpaceRelation
@@ -160,7 +160,7 @@ class Perception:
     actor_id: ObjectId
     source_id: ObjectId  # ID of the world or space this perception is derived from
     schema_version: str = "1.0"
-    timestamp: Optional[Any] = None
+    timestamp: Optional[Union[int, float, str]] = None
     perceived_spaces: Dict[SpaceId, PerceivedSpace] = field(default_factory=dict)
     perceived_memberships: List[PerceivedMembership] = field(default_factory=list)
     perceived_relations: List[PerceivedRelation] = field(default_factory=list)

--- a/src/masm/model/sensor.py
+++ b/src/masm/model/sensor.py
@@ -22,9 +22,11 @@ Core specs addressed: A-9, A-10, A-11, F-5, F-14.
 
 from __future__ import annotations
 
+import copy
+import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .perception import (
     VALID_EPISTEMIC_STATUSES,
@@ -195,17 +197,35 @@ class Sensor:
 
     # --- Public API ---------------------------------------------------------
 
-    def sense(self, world: World, actor_id: ObjectId) -> Perception:
+    def sense(
+        self,
+        world: World,
+        actor_id: ObjectId,
+        timestamp: Optional[Any] = None,
+    ) -> Perception:
         """Build a Perception of the given world for the given actor.
 
         The returned Perception is fully insulated: subsequent changes to
         the world do not affect it, and noise applied during sensing does
         not mutate the original world objects.
+
+        Parameters
+        ----------
+        timestamp:
+            Optional simulation timestamp for this snapshot. When provided
+            it is embedded in the perception ID, making the ID deterministic
+            for the (actor_id, world.id, timestamp) triplet. When omitted a
+            random UUID suffix ensures uniqueness across calls.
         """
+        if timestamp is not None:
+            perception_id = f"perception-{actor_id}-{world.id}-{timestamp}"
+        else:
+            perception_id = f"perception-{actor_id}-{world.id}-{uuid.uuid4().hex}"
         perception = Perception(
-            id=f"perception-{actor_id}-{world.id}",
+            id=perception_id,
             actor_id=actor_id,
             source_id=world.id,
+            timestamp=timestamp,
         )
         self._sense_spaces(world, actor_id, perception)
         self._sense_memberships(world, actor_id, perception)
@@ -221,7 +241,7 @@ class Sensor:
             if not self._covers_space(space, actor_id, world):
                 continue
             # Deep copy before noise so the world is never mutated.
-            space_copy = Space.from_dict(space.to_dict())
+            space_copy = copy.deepcopy(space)
             space_copy, noise_meta = self._apply_noise_to_space(space_copy, actor_id)
             perception.perceived_spaces[space_id] = PerceivedSpace(
                 space=space_copy,
@@ -235,7 +255,7 @@ class Sensor:
         for membership in world.space_object_graph.object_memberships:
             if not self._covers_membership(membership, actor_id, world):
                 continue
-            membership_copy = SpaceObjectMembership.from_dict(membership.to_dict())
+            membership_copy = copy.deepcopy(membership)
             membership_copy, noise_meta = self._apply_noise_to_membership(
                 membership_copy, actor_id
             )
@@ -253,7 +273,7 @@ class Sensor:
         for relation in world.space_relation_graph.relations:
             if not self._covers_relation(relation, actor_id, world):
                 continue
-            relation_copy = SpaceRelation.from_dict(relation.to_dict())
+            relation_copy = copy.deepcopy(relation)
             relation_copy, noise_meta = self._apply_noise_to_relation(
                 relation_copy, actor_id
             )

--- a/src/masm/model/sensor.py
+++ b/src/masm/model/sensor.py
@@ -26,7 +26,7 @@ import copy
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .perception import (
     VALID_EPISTEMIC_STATUSES,
@@ -201,7 +201,7 @@ class Sensor:
         self,
         world: World,
         actor_id: ObjectId,
-        timestamp: Optional[Any] = None,
+        timestamp: Optional[Union[int, float, str]] = None,
     ) -> Perception:
         """Build a Perception of the given world for the given actor.
 
@@ -212,13 +212,19 @@ class Sensor:
         Parameters
         ----------
         timestamp:
-            Optional simulation timestamp for this snapshot. When provided
-            it is embedded in the perception ID, making the ID deterministic
-            for the (actor_id, world.id, timestamp) triplet. When omitted a
+            Optional simulation timestamp for this snapshot. Must be an
+            ``int``, ``float``, or ``str`` to guarantee a deterministic
+            string representation. When provided it is embedded in the
+            perception ID, making the ID deterministic for the
+            (actor_id, world.id, timestamp) triplet. When omitted a
             random UUID suffix ensures uniqueness across calls.
         """
         if timestamp is not None:
-            perception_id = f"perception-{actor_id}-{world.id}-{timestamp}"
+            if not isinstance(timestamp, (int, float, str)):
+                raise TypeError(
+                    f"timestamp must be int, float, or str, got {type(timestamp).__name__}"
+                )
+            perception_id = f"perception-{actor_id}-{world.id}-{timestamp!s}"
         else:
             perception_id = f"perception-{actor_id}-{world.id}-{uuid.uuid4().hex}"
         perception = Perception(

--- a/src/masm/model/space_relations.py
+++ b/src/masm/model/space_relations.py
@@ -117,12 +117,13 @@ class SpaceRelation:
     def __deepcopy__(self, memo: dict) -> "SpaceRelation":
         """Optimised deep copy: immutable str fields are shared; only
         the mutable metadata dict is deep-copied."""
-        new_obj: SpaceRelation = SpaceRelation.__new__(SpaceRelation)
+        cls = self.__class__
+        new_obj: SpaceRelation = cls.__new__(cls)
         memo[id(self)] = new_obj
-        object.__setattr__(new_obj, "source_space_id", self.source_space_id)
-        object.__setattr__(new_obj, "target_space_id", self.target_space_id)
-        object.__setattr__(new_obj, "relation_type", self.relation_type)
-        object.__setattr__(new_obj, "metadata", copy.deepcopy(self.metadata, memo))
+        for f in dataclasses.fields(self):
+            object.__setattr__(
+                new_obj, f.name, copy.deepcopy(getattr(self, f.name), memo)
+            )
         return new_obj
 
     @classmethod

--- a/src/masm/model/space_relations.py
+++ b/src/masm/model/space_relations.py
@@ -14,6 +14,7 @@ Object-to-space memberships are managed separately in spaces.py.
 from __future__ import annotations
 
 import copy
+import dataclasses
 from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Optional, Any
 

--- a/src/masm/model/space_relations.py
+++ b/src/masm/model/space_relations.py
@@ -13,6 +13,7 @@ Object-to-space memberships are managed separately in spaces.py.
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Optional, Any
 
@@ -112,6 +113,17 @@ class SpaceRelation:
             "relation_type": self.relation_type,
             "metadata": dict(sorted(self.metadata.items())),
         }
+
+    def __deepcopy__(self, memo: dict) -> "SpaceRelation":
+        """Optimised deep copy: immutable str fields are shared; only
+        the mutable metadata dict is deep-copied."""
+        new_obj: SpaceRelation = SpaceRelation.__new__(SpaceRelation)
+        memo[id(self)] = new_obj
+        object.__setattr__(new_obj, "source_space_id", self.source_space_id)
+        object.__setattr__(new_obj, "target_space_id", self.target_space_id)
+        object.__setattr__(new_obj, "relation_type", self.relation_type)
+        object.__setattr__(new_obj, "metadata", copy.deepcopy(self.metadata, memo))
+        return new_obj
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "SpaceRelation":

--- a/src/masm/model/spaces.py
+++ b/src/masm/model/spaces.py
@@ -17,6 +17,7 @@ Space-to-space relations are managed separately through the space_relations modu
 from __future__ import annotations
 
 import copy
+import dataclasses
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Iterable, Mapping
 
@@ -147,21 +148,22 @@ class Space(GenericObject):
         )
 
     def __deepcopy__(self, memo: dict) -> "Space":
-        """Optimised deep copy: immutable str fields are shared; only mutable
-        dicts/lists are copied, avoiding the overhead of full deepcopy traversal."""
-        new_obj: Space = self.__class__.__new__(self.__class__)
+        """Deep copy that iterates over all dataclass fields dynamically.
+
+        Using ``dataclasses.fields()`` instead of an explicit field list keeps
+        this correct for subclasses that introduce new fields, without any
+        additional work required from those subclasses.
+        ``copy.deepcopy`` already returns immutable values (str, int, …)
+        unchanged, so no performance is lost compared to the previous
+        hand-written approach.
+        """
+        cls = self.__class__
+        new_obj = cls.__new__(cls)
         memo[id(self)] = new_obj
-        # str fields are immutable — safe to share directly
-        new_obj.id = self.id
-        new_obj.object_type = self.object_type
-        new_obj.schema_version = self.schema_version
-        # dict/list fields are mutable — deep-copy each one
-        new_obj.attributes = copy.deepcopy(self.attributes, memo)
-        # relations values are List[str]; a per-list copy is sufficient
-        new_obj.relations = {k: list(v) for k, v in self.relations.items()}
-        new_obj.state = copy.deepcopy(self.state, memo)
-        new_obj.context = copy.deepcopy(self.context, memo)
-        new_obj.provenance = copy.deepcopy(self.provenance, memo)
+        for f in dataclasses.fields(self):
+            object.__setattr__(
+                new_obj, f.name, copy.deepcopy(getattr(self, f.name), memo)
+            )
         return new_obj
 
     @classmethod

--- a/src/masm/model/spaces.py
+++ b/src/masm/model/spaces.py
@@ -209,13 +209,13 @@ class SpaceObjectMembership:
     def __deepcopy__(self, memo: dict) -> "SpaceObjectMembership":
         """Optimised deep copy: immutable str fields are shared; mutable
         dicts are deep-copied to ensure full insulation."""
-        new_obj: SpaceObjectMembership = SpaceObjectMembership.__new__(SpaceObjectMembership)
+        cls = self.__class__
+        new_obj: SpaceObjectMembership = cls.__new__(cls)
         memo[id(self)] = new_obj
-        new_obj.object_id = self.object_id
-        new_obj.space_id = self.space_id
-        new_obj.role = self.role
-        new_obj.validity = copy.deepcopy(self.validity, memo)
-        new_obj.metadata = copy.deepcopy(self.metadata, memo)
+        for f in dataclasses.fields(self):
+            object.__setattr__(
+                new_obj, f.name, copy.deepcopy(getattr(self, f.name), memo)
+            )
         return new_obj
 
     @classmethod

--- a/src/masm/model/spaces.py
+++ b/src/masm/model/spaces.py
@@ -206,7 +206,7 @@ class SpaceObjectMembership:
 
     def __deepcopy__(self, memo: dict) -> "SpaceObjectMembership":
         """Optimised deep copy: immutable str fields are shared; mutable
-        dicts are shallow-copied (values are conventionally primitives)."""
+        dicts are deep-copied to ensure full insulation."""
         new_obj: SpaceObjectMembership = SpaceObjectMembership.__new__(SpaceObjectMembership)
         memo[id(self)] = new_obj
         new_obj.object_id = self.object_id

--- a/src/masm/model/spaces.py
+++ b/src/masm/model/spaces.py
@@ -16,6 +16,7 @@ Space-to-space relations are managed separately through the space_relations modu
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Iterable, Mapping
 
@@ -145,6 +146,24 @@ class Space(GenericObject):
             " managed through the space_relations module"
         )
 
+    def __deepcopy__(self, memo: dict) -> "Space":
+        """Optimised deep copy: immutable str fields are shared; only mutable
+        dicts/lists are copied, avoiding the overhead of full deepcopy traversal."""
+        new_obj: Space = self.__class__.__new__(self.__class__)
+        memo[id(self)] = new_obj
+        # str fields are immutable — safe to share directly
+        new_obj.id = self.id
+        new_obj.object_type = self.object_type
+        new_obj.schema_version = self.schema_version
+        # dict/list fields are mutable — deep-copy each one
+        new_obj.attributes = copy.deepcopy(self.attributes, memo)
+        # relations values are List[str]; a per-list copy is sufficient
+        new_obj.relations = {k: list(v) for k, v in self.relations.items()}
+        new_obj.state = copy.deepcopy(self.state, memo)
+        new_obj.context = copy.deepcopy(self.context, memo)
+        new_obj.provenance = copy.deepcopy(self.provenance, memo)
+        return new_obj
+
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "Space":
         """Create a Space instance from a dictionary representation."""
@@ -184,6 +203,18 @@ class SpaceObjectMembership:
             "validity": dict(sorted(self.validity.items())),
             "metadata": dict(sorted(self.metadata.items())),
         }
+
+    def __deepcopy__(self, memo: dict) -> "SpaceObjectMembership":
+        """Optimised deep copy: immutable str fields are shared; mutable
+        dicts are shallow-copied (values are conventionally primitives)."""
+        new_obj: SpaceObjectMembership = SpaceObjectMembership.__new__(SpaceObjectMembership)
+        memo[id(self)] = new_obj
+        new_obj.object_id = self.object_id
+        new_obj.space_id = self.space_id
+        new_obj.role = self.role
+        new_obj.validity = copy.deepcopy(self.validity, memo)
+        new_obj.metadata = copy.deepcopy(self.metadata, memo)
+        return new_obj
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "SpaceObjectMembership":

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -778,14 +778,25 @@ def test_sensor_multi_space_actor_perception():
 
 
 def test_sensor_perception_id_is_deterministic():
-    """The same (actor_id, world.id) always produces the same perception ID."""
+    """Same (actor_id, world.id, timestamp) always produces the same perception ID."""
     world = _build_world("w-id-1")
+    sensor = Sensor()
+
+    p1 = sensor.sense(world, "actor-1", timestamp=42)
+    p2 = sensor.sense(world, "actor-1", timestamp=42)
+
+    assert p1.id == p2.id
+
+
+def test_sensor_perception_id_is_unique_without_timestamp():
+    """Without a timestamp, each call produces a unique perception ID."""
+    world = _build_world("w-id-2")
     sensor = Sensor()
 
     p1 = sensor.sense(world, "actor-1")
     p2 = sensor.sense(world, "actor-1")
 
-    assert p1.id == p2.id
+    assert p1.id != p2.id
 
 
 def test_sensor_identity_noise_rule_no_metadata():


### PR DESCRIPTION
| Issue | File | Fix |
|---|---|---|
| **#25** (medium) — `GenericObject` id validation regression | objects.py | `__post_init__` now raises `ValueError` when `id` is empty |
| **#26** (medium) — `Perception.to_dict()` non-deterministic order | perception.py | `perceived_memberships` and `perceived_relations` are now sorted by natural keys |
| **#24** (medium) — Inefficient serialization-based deep copy | sensor.py | Replaced `from_dict(to_dict())` calls with `copy.deepcopy()` for spaces, memberships, and relations |
| **#23** (medium) — `timestamp` field never populated | sensor.py | `sense()` accepts an optional `timestamp` parameter and assigns it to the `Perception` |
| **#22** (high) — Perception ID collision risk | sensor.py + test_model.py | ID now includes a UUID suffix when no timestamp is given; deterministic when `timestamp` is provided. New test `test_sensor_perception_id_is_unique_without_timestamp` added |
