### PR TITLE
DRY refactoring run

### DIFF
--- a/.github/workflows/contributors_update.yaml
+++ b/.github/workflows/contributors_update.yaml
@@ -6,13 +6,23 @@ name: Ometeotl Contributors
 # in contributors
 
 on:
+  # Recalculate daily at 06:00 UTC (recency factors change every day)
+  schedule:
+    - cron: '0 6 * * *'
+
+  # Recalculate after every rank assignment (i.e. after every merged PR)
   workflow_run:
     workflows: ["Ometeotl Rank"]
     types: [completed]
 
+  # Manual trigger for testing or recalibration
+  workflow_dispatch:
+
 permissions:
   contents: write
   actions: read
+  pull-requests: read
+  issues: write
 
 jobs:
   update-contributors:
@@ -180,18 +190,43 @@ jobs:
       - name: Commit and push CONTRIBUTORS.md
         env:
           GITHUB_TOKEN: ${{ secrets.OMETEOTL_BOT_TOKEN_CONTRIBUTORS }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # MODIFIED: configure bot identity and push only when CONTRIBUTORS.md changed
           git config --local user.name "ometeotl-bot"
           git config --local user.email "bot@ometeotl.local"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
           git add CONTRIBUTORS.md
-
           if git diff --cached --quiet; then
-            echo "No changes to commit"
+            echo "No changes to commit."
           else
-            USERNAME="$(node -p "require('./rank-data.json').username")"
-            git commit -m "docs(contributors): update @${USERNAME}"   
-            git push origin HEAD:develop
-          fi
+            git commit -m "docs(leaderboard): update activity shares [$(date -u +%Y-%m-%d)]"
+
+            if git pull --no-rebase origin develop; then
+              git push origin HEAD:develop
+            else
+              echo "::warning::Merge conflict during Contributors update. Aborting merge and opening an issue."
+              git merge --abort
+
+              # Reset to clean state (drop the contributors commit)
+              git reset --hard origin/develop
+
+              # Open a GitHub issue to alert maintainers
+              gh issue create \
+                --repo "${{ github.repository }}" \
+                --title "[contributors-bot] Merge conflict on develop" \
+                --label "bot,contributors" \
+                --body "The automated leaderboard update failed due to a merge conflict on \`develop\`.
+
+              **What happened:**
+              The contributors workflow committed updated scores, but \`develop\` had diverged with conflicting changes in one of these paths:
+              - \`CONTRIBUTORS.md`
+
+              **What to do:**
+              1. Manually run the contributors workflow after resolving the conflicting files.
+              2. Or wait — the next scheduled run (daily at 06:00 UTC) will retry automatically.
+
+              **Run:** [$(date -u +%Y-%m-%dT%H:%M:%SZ)](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+                            exit 0  # Don't fail the workflow — the issue is the alert
+                          fi
+                        fi

--- a/src/masm/model/actions.py
+++ b/src/masm/model/actions.py
@@ -56,7 +56,9 @@ class ResourceEffect:
         return cls(
             resource_id=str(data["resource_id"]),
             effect_type=str(data.get("effect_type") or "consume"),
-            quantity=float(data["quantity"]) if data.get("quantity") is not None else 1.0,
+            quantity=(
+                float(data["quantity"]) if data.get("quantity") is not None else 1.0
+            ),
             source_id=str(data["source_id"]) if data.get("source_id") else None,
             target_id=str(data["target_id"]) if data.get("target_id") else None,
             metadata=dict(data.get("metadata") or {}),

--- a/src/masm/model/actions.py
+++ b/src/masm/model/actions.py
@@ -15,12 +15,9 @@ F-1 (canonical serialization).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
-from .base import ModelObject, RelationMap
-
-JsonMap = Dict[str, Any]
-ObjectId = str
+from .base import ModelObject, ObjectId, JsonMap, RelationMap
 
 
 @dataclass

--- a/src/masm/model/actors.py
+++ b/src/masm/model/actors.py
@@ -28,19 +28,11 @@ relations, and modeling conventions to be introduced progressively.
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping
+from typing import Any, List, Mapping
 
-from .base import ModelObject, relation_methods
+from .base import ModelObject, ObjectId, JsonMap, relation_methods
 from .objects import GenericObject
 from .spaces import SpaceObjectGraph, SpaceObjectMembership
-
-# local aliases
-JsonMap = Dict[str, Any]
-ObjectId = str
-
-
-def _default_schema_version() -> str:
-    return "1.0"
 
 
 @relation_methods("action", "action")
@@ -77,7 +69,7 @@ class Actor(GenericObject):
         self.attributes.setdefault("kind", "generic")
         self.attributes.setdefault("tags", [])
         self.attributes.setdefault("roles", [])
-        self.attributes.setdefault("profiles", {})
+        self.attributes.setdefault("profile", {})
         self.attributes.setdefault("emergent", False)
         self.attributes.setdefault("composition_mode", "standalone")
 
@@ -102,24 +94,6 @@ class Actor(GenericObject):
         self.attributes["kind"] = value
 
     @property
-    def tags(self) -> List[str]:
-        """Return the actor's tags.
-
-        Tags are simple labels that can be used for categorization,
-        filtering, or search.
-        """
-        value = self.attributes.get("tags", [])
-        return sorted(list(value)) if value is not None else []
-
-    def add_tag(self, tag: str) -> None:
-        """Adds a tag to the actor."""
-        self.add_to_attribute_list("tags", tag)
-
-    def remove_tag(self, tag: str) -> None:
-        """Removes a tag from the actor."""
-        self.remove_from_attribute_list("tags", tag)
-
-    @property
     def roles(self) -> List[str]:
         """Return the actor's roles.
 
@@ -136,27 +110,6 @@ class Actor(GenericObject):
     def remove_role(self, role: str) -> None:
         """Removes a role from the actor."""
         self.remove_from_attribute_list("roles", role)
-
-    @property
-    def profile(self) -> JsonMap:
-        """Return the actor's free-form profile.
-
-        Structured data that can be used to capture specific characteristics,
-        preferences, or attributes of the actor in a more detailed and
-        organized way. This dictionary is intentionally open-ended and can
-        contain modeling details such as category-specific metadata,
-        identifiers, demographic information etc.
-        """
-        value = self.attributes.get("profile", {})
-        return dict(value) if isinstance(value, Mapping) else {}
-
-    def set_profile_item(self, key: str, value: Any) -> None:
-        """Sets a specific item in the actor's profile."""
-        if not key:
-            raise ValueError("Profile key cannot be empty")
-        profile = self.profile
-        profile[key] = value
-        self.attributes["profile"] = dict(sorted(profile.items()))
 
     @property
     def emergent(self) -> bool:
@@ -236,9 +189,9 @@ class Actor(GenericObject):
         )
 
     def remove_space_membership(
-        self, graph: "SpaceObjectGraph", space_id: ObjectId, role
+        self, graph: "SpaceObjectGraph", space_id: ObjectId, role: str = "occupies"
     ) -> None:
-        """Remove the declaration that this resource exists in a given space.
+        """Remove the declaration that this actor exists in a given space.
 
         Important:
         This method is only a convenience wrapper around SpaceObjectMembership
@@ -259,29 +212,4 @@ class Actor(GenericObject):
         payload = dict(data)
         payload["object_type"] = payload.get("object_type") or "actor"
         base_obj = ModelObject.from_dict(payload)
-        return cls(
-            id=base_obj.id,
-            object_type=base_obj.object_type,
-            schema_version=base_obj.schema_version,
-            attributes=base_obj.attributes,
-            relations=base_obj.relations,
-            state=base_obj.state,
-            context=base_obj.context,
-            provenance=base_obj.provenance,
-        )
-
-    def to_dict(self) -> JsonMap:
-        """Convert the Actor instance to a dictionary representation."""
-        return {
-            "id": self.id,
-            "object_type": self.object_type,
-            "schema_version": self.schema_version,
-            "attributes": dict(self.attributes),
-            "relations": {
-                key: sorted(list(set(value)))
-                for key, value in dict(self.relations).items()
-            },
-            "state": dict(self.state),
-            "context": dict(self.context),
-            "provenance": dict(self.provenance),
-        }
+        return cls(**base_obj._base_kwargs())

--- a/src/masm/model/base.py
+++ b/src/masm/model/base.py
@@ -162,6 +162,23 @@ class ModelObject:
             "provenance": dict(sorted(self.provenance.items())),
         }
 
+    def _base_kwargs(self) -> "JsonMap":
+        """Return the base keyword arguments shared by all ModelObject subclasses.
+
+        Intended for use inside subclass ``from_dict`` implementations to avoid
+        repeating the eight common field assignments.
+        """
+        return {
+            "id": self.id,
+            "object_type": self.object_type,
+            "schema_version": self.schema_version,
+            "attributes": self.attributes,
+            "relations": self.relations,
+            "state": self.state,
+            "context": self.context,
+            "provenance": self.provenance,
+        }
+
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "ModelObject":
         return cls(

--- a/src/masm/model/objects.py
+++ b/src/masm/model/objects.py
@@ -79,6 +79,6 @@ class GenericObject(ModelObject):
         """Set a specific item in the object's profile."""
         if not key:
             raise ValueError("Profile key cannot be empty")
-        profile = dict(self.profile)
+        profile = self.profile
         profile[key] = value
         self.attributes["profile"] = dict(sorted(profile.items()))

--- a/src/masm/model/objects.py
+++ b/src/masm/model/objects.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, List, Mapping, Optional
 
 from .base import ModelObject
 
@@ -47,3 +47,38 @@ class GenericObject(ModelObject):
         if not value:
             raise ValueError("Description cannot be empty")
         self.attributes["description"] = value
+
+    @property
+    def tags(self) -> List[str]:
+        """Get the object's tags.
+
+        Tags are simple labels used for categorization, filtering, or search.
+        """
+        value = self.attributes.get("tags", [])
+        return sorted(list(value)) if value is not None else []
+
+    def add_tag(self, tag: str) -> None:
+        """Add a tag to the object."""
+        self.add_to_attribute_list("tags", tag)
+
+    def remove_tag(self, tag: str) -> None:
+        """Remove a tag from the object."""
+        self.remove_from_attribute_list("tags", tag)
+
+    @property
+    def profile(self) -> Mapping[str, Any]:
+        """Get the object's free-form profile.
+
+        Structured data capturing specific characteristics or attributes of
+        the object in a detailed and organized way. Intentionally open-ended.
+        """
+        value = self.attributes.get("profile", {})
+        return dict(value) if isinstance(value, Mapping) else {}
+
+    def set_profile_item(self, key: str, value: Any) -> None:
+        """Set a specific item in the object's profile."""
+        if not key:
+            raise ValueError("Profile key cannot be empty")
+        profile = dict(self.profile)
+        profile[key] = value
+        self.attributes["profile"] = dict(sorted(profile.items()))

--- a/src/masm/model/objects.py
+++ b/src/masm/model/objects.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, List, Mapping, Optional
 
-from .base import ModelObject
+from .base import ModelObject, JsonMap
 
 
 @dataclass

--- a/src/masm/model/objects.py
+++ b/src/masm/model/objects.py
@@ -66,7 +66,7 @@ class GenericObject(ModelObject):
         self.remove_from_attribute_list("tags", tag)
 
     @property
-    def profile(self) -> Mapping[str, Any]:
+    def profile(self) -> JsonMap:
         """Get the object's free-form profile.
 
         Structured data capturing specific characteristics or attributes of

--- a/src/masm/model/perception.py
+++ b/src/masm/model/perception.py
@@ -19,13 +19,12 @@ Each perceived element carries:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional, Union
 
+from .base import ObjectId, JsonMap
 from .spaces import Space, SpaceObjectMembership
 from .space_relations import SpaceRelation
 
-JsonMap = Dict[str, Any]
-ObjectId = str
 SpaceId = str
 
 VALID_EPISTEMIC_STATUSES: frozenset = frozenset(

--- a/src/masm/model/resources.py
+++ b/src/masm/model/resources.py
@@ -19,19 +19,11 @@ intended business logic.
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any, List, Dict, Mapping
+from typing import Any, Mapping
 
-from .base import ModelObject, relation_methods
+from .base import ModelObject, ObjectId, JsonMap, relation_methods
 from .objects import GenericObject
 from .spaces import SpaceObjectGraph, SpaceObjectMembership
-
-# local aliases
-JsonMap = Dict[str, Any]
-ObjectId = str
-
-
-def _default_schema_version() -> str:
-    return "1.0"
 
 
 @relation_methods("user", "used_by")
@@ -109,20 +101,6 @@ class Resource(GenericObject):
         self.attributes["kind"] = str(value)
 
     @property
-    def tags(self) -> List[str]:
-        """The tags of the resource."""
-        value = self.attributes.get("tags", [])
-        return sorted(list(value)) if value is not None else []
-
-    def add_tag(self, tag: str) -> None:
-        """Add a tag to the resource."""
-        self.add_to_attribute_list("tags", tag)
-
-    def remove_tag(self, tag: str) -> None:
-        """Remove a tag from the resource."""
-        self.remove_from_attribute_list("tags", tag)
-
-    @property
     def resource_mode(self) -> str:
         """The resource mode of the resource."""
         value = self.attributes.get("resource_mode", "stock")
@@ -185,25 +163,6 @@ class Resource(GenericObject):
         """Set whether the resource is composite."""
         self.attributes["composite"] = bool(value)
 
-    @property
-    def profile(self) -> JsonMap:
-        """Returns the free-form profile of the resource, which are structured
-        data that can be used to capture specific characteristics, preferences,
-        or attributes of the resource in a more detailed and organized way.
-        This dictionnary is intentionally open-ended and can contain
-        modeling details such as category-specific metadata,
-        identifiers etc."""
-        value = self.attributes.get("profile", {})
-        return dict(value) if isinstance(value, Mapping) else {}
-
-    def set_profile_item(self, key: str, value: Any) -> None:
-        """Sets a specific item in the resource's profile."""
-        if not key:
-            raise ValueError("Profile key cannot be empty")
-        profile = self.profile
-        profile[key] = value
-        self.attributes["profile"] = dict(sorted(profile.items()))
-
     # ------------------------------------------------------------------
     # Domain relations
     # ------------------------------------------------------------------
@@ -265,13 +224,4 @@ class Resource(GenericObject):
         payload = dict(data)
         payload["object_type"] = payload.get("object_type") or "resource"
         base_obj = ModelObject.from_dict(payload)
-        return cls(
-            id=base_obj.id,
-            object_type=base_obj.object_type,
-            schema_version=base_obj.schema_version,
-            attributes=base_obj.attributes,
-            relations=base_obj.relations,
-            state=base_obj.state,
-            context=base_obj.context,
-            provenance=base_obj.provenance,
-        )
+        return cls(**base_obj._base_kwargs())

--- a/src/masm/model/sensor.py
+++ b/src/masm/model/sensor.py
@@ -40,7 +40,6 @@ from .spaces import Space, SpaceObjectMembership
 from .space_relations import SpaceRelation
 from .world import World
 
-
 # ---------------------------------------------------------------------------
 # Coverage rules
 # ---------------------------------------------------------------------------

--- a/src/masm/model/sensor.py
+++ b/src/masm/model/sensor.py
@@ -26,8 +26,9 @@ import copy
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
+from .base import ObjectId, JsonMap
 from .perception import (
     VALID_EPISTEMIC_STATUSES,
     Perception,
@@ -38,9 +39,6 @@ from .perception import (
 from .spaces import Space, SpaceObjectMembership
 from .space_relations import SpaceRelation
 from .world import World
-
-JsonMap = Dict[str, Any]
-ObjectId = str
 
 
 # ---------------------------------------------------------------------------

--- a/src/masm/model/space_relations.py
+++ b/src/masm/model/space_relations.py
@@ -18,8 +18,9 @@ import dataclasses
 from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Optional, Any
 
+from .base import JsonMap
+
 SpaceId = str
-JsonMap = Dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/src/masm/model/spaces.py
+++ b/src/masm/model/spaces.py
@@ -19,17 +19,10 @@ from __future__ import annotations
 import copy
 import dataclasses
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Iterable, Mapping
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
-from .base import ModelObject
+from .base import ModelObject, ObjectId, JsonMap
 from .objects import GenericObject
-
-JsonMap = Dict[str, Any]
-ObjectId = str
-
-
-def _default_schema_version() -> str:
-    return "1.0"
 
 
 @dataclass
@@ -70,23 +63,6 @@ class Space(GenericObject):
         if not value:
             raise ValueError("Kind cannot be empty")
         self.attributes["kind"] = str(value)
-
-    @property
-    def tags(self) -> List[str]:
-        """Get the list of tags associated with the space.
-        Tags are simple labels that can be used to categorize or describe the
-        space in a flexible way.
-        """
-        value = self.attributes.get("tags", [])
-        return sorted(list(value)) if value is not None else []
-
-    def add_tag(self, tag: str) -> None:
-        """Add a tag to the space."""
-        self.add_to_attribute_list("tags", tag)
-
-    def remove_tag(self, tag: str) -> None:
-        """Remove a tag from the space."""
-        self.remove_from_attribute_list("tags", tag)
 
     @property
     def dimensions(self) -> JsonMap:
@@ -173,16 +149,7 @@ class Space(GenericObject):
         payload = dict(data)
         payload["object_type"] = payload.get("object_type") or "space"
         base_obj = ModelObject.from_dict(payload)
-        return cls(
-            id=base_obj.id,
-            object_type=base_obj.object_type,
-            schema_version=base_obj.schema_version,
-            attributes=base_obj.attributes,
-            relations=base_obj.relations,
-            state=base_obj.state,
-            context=base_obj.context,
-            provenance=base_obj.provenance,
-        )
+        return cls(**base_obj._base_kwargs())
 
 
 @dataclass

--- a/src/masm/model/world.py
+++ b/src/masm/model/world.py
@@ -13,15 +13,13 @@ must be registered in the minimal registry.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Mapping, Optional
-from .base import ModelObject
+from typing import Any, Mapping, Optional
+from .base import ModelObject, ObjectId, JsonMap
 from .spaces import Space, SpaceObjectGraph, SpaceObjectMembership
 from .space_relations import SpaceRelation, SpaceRelationGraph
 from .registry import MinimalModelRegistry
 from .objects import GenericObject
 
-JsonMap = Dict[str, Any]
-ObjectId = str
 SpaceId = str
 
 
@@ -114,14 +112,7 @@ class World(Space):
         attributes = base_obj.attributes
         is_root_world = bool(attributes.get("is_root_world", True))
         return cls(
-            id=base_obj.id,
-            object_type=base_obj.object_type,
-            schema_version=base_obj.schema_version,
-            attributes=attributes,
-            relations=base_obj.relations,
-            state=base_obj.state,
-            context=base_obj.context,
-            provenance=base_obj.provenance,
+            **base_obj._base_kwargs(),
             is_root_world=is_root_world,
             space_object_graph=SpaceObjectGraph.from_dict(
                 data.get("space_object_graph") or {}


### PR DESCRIPTION
Completed: *Apply DRY refactoring* 

| Violation | Fix |
|---|---|
| `_default_schema_version()` redefined in actors.py, resources.py, spaces.py (unused dead code) | Removed from all three files |
| `JsonMap = Dict[str, Any]` / `ObjectId = str` redefined in 7 files | Removed local redefinitions; import from base.py in `actors`, `resources`, `spaces`, `world`, `actions`, `perception`, `sensor`, `space_relations` |
| `tags` + `add_tag` + `remove_tag` triplicated in actors.py, resources.py, spaces.py | Consolidated in `GenericObject` (objects.py); removed from all three subclasses |
| `profile` + `set_profile_item` duplicated in actors.py and resources.py | Consolidated in `GenericObject`; removed from both subclasses |
| `Actor.to_dict()` reinvented `ModelObject.to_dict()` incorrectly (unsorted keys, no determinism per F-6) | Removed; `ModelObject.to_dict()` is now used via inheritance |
| `from_dict` boilerplate (8 repeated field assignments) repeated in `Actor`, `Resource`, `Space`, `World` | Added `ModelObject._base_kwargs()` helper; all four `from_dict` methods simplified to `cls(**base_obj._base_kwargs(), ...)` |
| `self.attributes.setdefault("profiles", {})` typo in `Actor.__post_init__` (wrong key vs `profile` property) | Fixed to `"profile"` |
| `remove_space_membership` in actors.py missing `role: str = "occupies"` default (inconsistent with resources.py) | Added default value |
