### PR TITLE
Feature/composite actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,42 @@ The name **Ometeotl** draws from Aztec mythology, where *Ōme* means "two" or "d
 
 ## Work in Progress
 
-This project is **actively under development**—a true work-in-progress. Current features include foundational axioms, basic serialization (JSON/YAML), and early game theory projections. Full validation pipelines, AI generation tools, and multi-agent simulations are planned for upcoming releases.
+This project is **actively under development**. The current codebase already implements a functional core centered on modeling, perception, projection, composite actors, and server-authoritative runtime boundaries, while validation, generation, IO packaging, and higher-level examples remain incomplete.
+
+## Current Implementation Status
+
+As of April 2026, the repository includes:
+
+- A full model core in `src/masm/model/` with `ModelObject`, `GenericObject`, `Actor`, `Resource`, `Space`, `World`, and registry support.
+- Spatial topology with `SpaceObjectGraph`, `SpaceObjectMembership`, `SpaceRelation`, and `SpaceRelationGraph`.
+- Composite and abstract actor support with explicit `component` links, composition modes, cycle detection, hierarchy traversal, and abstract-space helpers.
+- A perception layer with `Perception`, `PerceivedSpace`, `PerceivedMembership`, `PerceivedRelation`, and `PerceivedComponentLink`.
+- A projection layer with `ProjectionAssumption`, `ProjectedPerceptionChange`, `ProjectedPerceptionState`, `ActionProjection`, `ProjectionBatch`, and the default projection tool.
+- A strategy layer with strategy nodes, outcome branches, linear and branching builders, and perception-driven chaining.
+- A sensor pipeline with coverage rules, noise rules, deterministic timestamp-aware perception ids, and epistemic status validation.
+- A server-authoritative core runtime with `AuthorityCommandHandler`, command envelopes/results, audit entries, and runtime bootstrap helpers.
+- A test suite currently collecting `188` tests across `tests/model/` and `tests/core/`.
+
+## Current Architecture
+
+The implemented architecture follows the separation defined in `specs_EN.md`:
+
+- `src/masm/model/` contains domain behavior and the canonical object graph.
+- `src/masm/core/` contains runtime and authority infrastructure, not domain rules.
+- Ontological state lives in `World`, `WorldModelRegistry`, `SpaceObjectGraph`, and `SpaceRelationGraph`.
+- Epistemic state lives in `Perception` and its perceived wrappers.
+- Projection derives successor perceived states from actions without mutating ontological truth directly.
+- Strategy building consumes projected perceptions rather than bypassing the perception layer.
+
+## Near-Term TODOs
+
+- Implement the dedicated `validation/` layer for structural, temporal, spatial, admissibility, and epistemic validation.
+- Implement the `io/` layer for explicit import/export workflows beyond object-local serialization helpers.
+- Implement the `generation/` layer and `from_context`-style construction pipeline.
+- Implement the `game/` layer beyond the current projection and strategy foundations.
+- Extend the strategy layer to support one action producing several alternative projected outcomes, with branch-specific successor perceived states carried by `StrategyOutcomeBranch` rather than duplicated on `StrategyNode`.
+- Add reference examples and end-to-end demo worlds in `examples/`.
+- Continue aligning public docs with the now-implemented projection, strategy, authority, and composite-actor capabilities.
 
 ## Join the Journey
 

--- a/doc-site/content/en/_index.md
+++ b/doc-site/content/en/_index.md
@@ -32,7 +32,25 @@ The name **Ometeotl** draws from Aztec mythology, where *Ōme* means "two" or "d
 
 ## Work in Progress
 
-This project is **actively under development**—a true work-in-progress. Current features include foundational axioms, basic serialization (JSON/YAML), and early game theory projections. Full validation pipelines, AI generation tools, and multi-agent simulations are planned for upcoming releases.
+This project is **actively under development**. The current repository already implements a functional core for modeling, perception, projection, composite and abstract actors, strategy building, and server-authoritative runtime control, while validation, generation, IO workflows, and end-to-end examples remain in progress.
+
+## Current Status
+
+- Functional model core with actors, resources, spaces, world, registry, and spatial graphs.
+- Composite actor hierarchies with explicit `component` links, traversal helpers, and abstract-space support.
+- Perception and sensor layers with epistemic statuses and perceived component links.
+- Projection and strategy layers with projected successor perceptions and perception-driven strategy chaining.
+- Authority/runtime boundary in `src/masm/core/` for server-owned world mutation flows.
+- Current automated baseline: `188` collected tests.
+
+## Near-Term TODOs
+
+- Implement the dedicated validation layer.
+- Implement dedicated IO workflows.
+- Implement contextual generation and repair.
+- Implement the full game layer beyond current projection and strategy foundations.
+- Extend the strategy layer to support one action emitting several alternative projected outcomes, with branch-specific successor perceived states on `StrategyOutcomeBranch`.
+- Add reference examples and end-to-end demo worlds.
 
 ## Join the Journey
 

--- a/doc-site/content/en/documentation/_index.md
+++ b/doc-site/content/en/documentation/_index.md
@@ -9,4 +9,4 @@ This section documents the current V1 implementation of the Ometeotl/MASM librar
 - Then use [Class Reference](/ometeotl/documentation/class-reference/) for complete API details.
 
 Scope note:
-This documentation reflects implemented code in [src/masm/core](https://github.com/kakchouch/ometeotl/tree/main/src/masm/core) and [src/masm/model](https://github.com/kakchouch/ometeotl/tree/main/src/masm/model/) and aligns with [specs_EN.md](https://github.com/kakchouch/ometeotl/blob/main/specs_EN.md).
+This documentation reflects the currently implemented code in [src/masm/core](https://github.com/kakchouch/ometeotl/tree/main/src/masm/core) and [src/masm/model](https://github.com/kakchouch/ometeotl/tree/main/src/masm/model/), including perception, projection, strategy, composite-actor, and authority/runtime behavior, and aligns with [specs_EN.md](https://github.com/kakchouch/ometeotl/blob/main/specs_EN.md).

--- a/doc-site/content/en/documentation/class-reference/model/actors/actor.md
+++ b/doc-site/content/en/documentation/class-reference/model/actors/actor.md
@@ -18,13 +18,30 @@ Inheritance:
 Parameters and fields:
 - `object_type: str = "actor"`
 - actor attributes: `kind`, `roles`, `emergent`, `composition_mode`
+- composition modes: `standalone`, `composite`, `collective`, `perceived`, `projected`
+- component relations are stored in `relations["component"]`
 
 Methods:
-- actor properties: `kind`, `roles`, `emergent`, `composition_mode`
+- actor properties: `kind`, `roles`, `emergent`, `composition_mode`, `is_composite`, `is_collective`
 - role methods: `add_role`, `remove_role`
+- component methods: `get_components`, `add_component`, `remove_component`
 - generated relation methods: `add_action/remove_action`, `add_resource/remove_resource`, `add_goal/remove_goal`, and related pairs
 - `from_dict(...)`
+
+Module-level helpers:
+- `detect_composition_cycle(...)` checks whether adding a component would create a cycle
+- `resolve_component_tree(...)` materializes a nested component hierarchy
+- `find_parent_composites(...)` finds reverse component links
+- `is_abstract_composite(...)` identifies a composite actor used as an abstraction node
+- `get_abstract_components(...)` returns direct non-abstract components
+- `get_real_world_base(...)` resolves the non-abstract leaves beneath an abstract hierarchy
+
+Notes:
+- Only actors in `composition_mode == "composite"` may carry explicit component links.
+- `collective` actors model a coherent whole without explicit component relations.
+- Composite actors support hierarchical nesting, while cycle creation is intentionally guarded by helper logic rather than being applied implicitly by `add_component(...)`.
 
 See also:
 - [Resource](/ometeotl/documentation/class-reference/model/resources/resource/)
 - [Perception](/ometeotl/documentation/class-reference/model/perception/perception/)
+- [Space](/ometeotl/documentation/class-reference/model/spaces/space/)

--- a/doc-site/content/en/documentation/class-reference/model/actors/actor.md
+++ b/doc-site/content/en/documentation/class-reference/model/actors/actor.md
@@ -33,7 +33,7 @@ Module-level helpers:
 - `resolve_component_tree(...)` materializes a nested component hierarchy
 - `find_parent_composites(...)` finds reverse component links
 - `is_abstract_composite(...)` identifies a composite actor used as an abstraction node
-- `get_abstract_components(...)` returns direct non-abstract components
+- `get_concrete_components(...)` returns direct non-abstract components
 - `get_real_world_base(...)` resolves the non-abstract leaves beneath an abstract hierarchy
 
 Notes:

--- a/doc-site/content/en/documentation/class-reference/model/perception/perceived-component-link.md
+++ b/doc-site/content/en/documentation/class-reference/model/perception/perceived-component-link.md
@@ -1,0 +1,36 @@
+---
+title: "PerceivedComponentLink"
+---
+
+Source:
+- [src/masm/model/perception.py](https://github.com/kakchouch/ometeotl/blob/main/src/masm/model/perception.py)
+
+Local role:
+Epistemic wrapper for one perceived composition edge between a composite actor and one component actor.
+
+Big-picture role:
+Lets [Perception](/ometeotl/documentation/class-reference/model/perception/perception/) represent actor hierarchy knowledge without mutating the ontological [Actor](/ometeotl/documentation/class-reference/model/actors/actor/) graph.
+
+Inheritance:
+- dataclass
+
+Parameters and fields:
+- `link_id: str`
+- `composite_id: ObjectId`
+- `component_id: ObjectId`
+- `epistemic_status: str`
+- `noise_metadata: JsonMap`
+
+Methods:
+- `to_dict(...)`
+- `from_dict(...)`
+- `__post_init__(...)`
+
+Notes:
+- `epistemic_status` follows the same validation rules as the other perceived wrappers.
+- This type is used both for sensed hierarchy knowledge and for projected hierarchy updates in successor perceived states.
+
+See also:
+- [Perception](/ometeotl/documentation/class-reference/model/perception/perception/)
+- [Actor](/ometeotl/documentation/class-reference/model/actors/actor/)
+- [ProjectedPerceptionChange](/ometeotl/documentation/class-reference/model/projection/projected-perception-change/)

--- a/doc-site/content/en/documentation/class-reference/model/perception/perception.md
+++ b/doc-site/content/en/documentation/class-reference/model/perception/perception.md
@@ -23,13 +23,19 @@ Parameters and fields:
 - perceived_spaces: Dict[SpaceId, [PerceivedSpace](/ometeotl/documentation/class-reference/model/perception/perceived-space/)]
 - perceived_memberships: List[[PerceivedMembership](/ometeotl/documentation/class-reference/model/perception/perceived-membership/)]
 - perceived_relations: List[[PerceivedRelation](/ometeotl/documentation/class-reference/model/perception/perceived-relation/)]
+- perceived_component_links: List[[PerceivedComponentLink](/ometeotl/documentation/class-reference/model/perception/perceived-component-link/)]
 - `context: JsonMap`
 - `provenance: JsonMap`
 
 Methods:
-- query helpers: `get_perceived_space`, `memberships_for_object`, `memberships_in_space`, `relations_for_space`
+- query helpers: `get_perceived_space`, `memberships_for_object`, `memberships_in_space`, `relations_for_space`, `component_links_for_composite`, `composite_for_component`
 - serialization: `to_dict`, `from_dict`
+
+Notes:
+- A perception can now carry perceived composition edges independently from space memberships and space-to-space relations.
+- Each perceived component link has its own epistemic status, allowing composition knowledge to remain uncertain, believed, projected, or erroneous without mutating ontological actor relations.
 
 See also:
 - [Actor](/ometeotl/documentation/class-reference/model/actors/actor/)
 - [World](/ometeotl/documentation/class-reference/model/world/world/)
+- [PerceivedComponentLink](/ometeotl/documentation/class-reference/model/perception/perceived-component-link/)

--- a/doc-site/content/en/documentation/class-reference/model/projection/projected-perception-change.md
+++ b/doc-site/content/en/documentation/class-reference/model/projection/projected-perception-change.md
@@ -22,9 +22,21 @@ Parameters and fields:
 - applied: Optional[bool]
 - metadata: dict
 
+Known `change_type` values:
+- `state_changes`
+- `resource_consume`
+- `resource_produce`
+- `object_added`
+- `object_removed`
+- `component_added`
+- `component_removed`
+
 Methods:
 - `to_dict() -> dict`
 - `from_dict(data) -> ProjectedPerceptionChange`
+
+Notes:
+- `component_added` and `component_removed` describe projected changes to perceived actor composition, not mutations of the ontological world model.
 
 See also:
 - [ProjectedPerceptionState](/ometeotl/documentation/class-reference/model/projection/projected-perception-state/)

--- a/doc-site/content/en/documentation/class-reference/model/projection/projected-perception-state.md
+++ b/doc-site/content/en/documentation/class-reference/model/projection/projected-perception-state.md
@@ -17,7 +17,7 @@ Inheritance:
 Parameters and fields:
 - `source_perception_id: str`
 - `generating_action_id: str`
-- `perception: Perception` — deep copy of the source perception, marked `epistemic_status="projected"` on all nested objects
+- `perception: Perception` — deep copy of the source perception, marked `epistemic_status="projected"` on perceived spaces, memberships, relations, and perceived component links
 - `changes: list[ProjectedPerceptionChange]` — sorted by `change_id` on serialization
 - `metadata: dict`
 
@@ -32,3 +32,4 @@ Methods:
 See also:
 - [ProjectedPerceptionChange](/ometeotl/documentation/class-reference/model/projection/projected-perception-change/)
 - [ActionProjection](/ometeotl/documentation/class-reference/model/projection/action-projection/)
+- [Perception](/ometeotl/documentation/class-reference/model/perception/perception/)

--- a/doc-site/content/en/documentation/class-reference/model/spaces/space.md
+++ b/doc-site/content/en/documentation/class-reference/model/spaces/space.md
@@ -17,13 +17,19 @@ Inheritance:
 
 Parameters and fields:
 - `object_type: str = "space"`
-- space attributes: `kind`, `dimensions`, `validity`
+- space attributes: `kind`, `dimensions`, `validity`, `is_abstract`
 
 Methods:
+- space properties: `kind`, `dimensions`, `validity`, `is_abstract`
 - dimension and validity methods: `set_dimension`, `set_validity`
 - legacy disabled methods: `add_member`, `remove_member`, `connect_to`
 - `from_dict(...)`, `__deepcopy__(...)`
 
+Notes:
+- `is_abstract` marks non-canonical spaces such as conceptual, analytical, or strategic grouping spaces.
+- Abstract spaces support the multi-space model described in the spec and can host abstraction-layer actors without changing the canonical world object model.
+
 See also:
 - [SpaceRelation](/ometeotl/documentation/class-reference/model/space-relations/space-relation/)
 - [SpaceObjectMembership](/ometeotl/documentation/class-reference/model/spaces/space-object-membership/)
+- [World](/ometeotl/documentation/class-reference/model/world/world/)

--- a/doc-site/content/en/documentation/class-reference/model/world/world.md
+++ b/doc-site/content/en/documentation/class-reference/model/world/world.md
@@ -26,8 +26,12 @@ Parameters and fields:
 Methods:
 - authority mode: `enable_authority_mode`, `disable_authority_mode`
 - topology operations: `add_space`, `add_space_relation`, `place_object`, `get_space`
+- abstract-space helper: `is_space_abstract`
 - registry operations: `register_object`, `unregister_object`
 - serialization: `to_dict`, `from_dict`
+
+Notes:
+- `is_space_abstract(space_id)` is a convenience query over registered spaces and returns `False` for unknown space ids.
 
 See also:
 - [Sensor](/ometeotl/documentation/class-reference/model/sensor/sensor/)

--- a/doc-site/content/en/documentation/overview.md
+++ b/doc-site/content/en/documentation/overview.md
@@ -29,6 +29,12 @@ Each actor can have a subjective, possibly imperfect view of the world:
 - [CoverageRule](/ometeotl/documentation/class-reference/model/sensor/coverage-rule/) controls what is visible
 - [NoiseRule](/ometeotl/documentation/class-reference/model/sensor/noise-rule/) controls how observed data is distorted
 
+Actors may also form explicit composite hierarchies and abstraction layers:
+
+- [Actor](/ometeotl/documentation/class-reference/model/actors/actor/) supports explicit `component` relations for `composite` actors and helper utilities for hierarchy traversal and cycle checks
+- [Space](/ometeotl/documentation/class-reference/model/spaces/space/) can be marked `is_abstract` to represent conceptual or analytical spaces alongside canonical spaces
+- [Perception](/ometeotl/documentation/class-reference/model/perception/perception/) can carry perceived component links, keeping composition knowledge in the epistemic layer when needed
+
 Candidate actions can then be projected from that perceived state into explicit future-facing strategy artifacts:
 
 - [DefaultProjectionTool](/ometeotl/documentation/class-reference/model/projection/default-projection-tool/) derives projection assumptions and successor perceived states
@@ -97,6 +103,8 @@ Deterministic ordering is enforced by canonical sort helpers and sorted list ser
 The ontology layer is [World](/ometeotl/documentation/class-reference/model/world/world/), [SpaceObjectGraph](/ometeotl/documentation/class-reference/model/spaces/space-object-graph/), [SpaceRelationGraph](/ometeotl/documentation/class-reference/model/space-relations/space-relation-graph/), and [WorldModelRegistry](/ometeotl/documentation/class-reference/model/registry/world-model-registry/).
 
 The epistemic layer is [Perception](/ometeotl/documentation/class-reference/model/perception/perception/), [PerceivedSpace](/ometeotl/documentation/class-reference/model/perception/perceived-space/), [PerceivedMembership](/ometeotl/documentation/class-reference/model/perception/perceived-membership/), and [PerceivedRelation](/ometeotl/documentation/class-reference/model/perception/perceived-relation/), created by [Sensor](/ometeotl/documentation/class-reference/model/sensor/sensor/) through composable [CoverageRule](/ometeotl/documentation/class-reference/model/sensor/coverage-rule/) and [NoiseRule](/ometeotl/documentation/class-reference/model/sensor/noise-rule/).
+
+Perceived actor composition is represented explicitly through [PerceivedComponentLink](/ometeotl/documentation/class-reference/model/perception/perceived-component-link/), which lets perceived hierarchies diverge from ontological hierarchies without mixing layers.
 
 This realizes reality/perception dissociation from the spec: decisions can be based on perceived states, not only ontological states.
 

--- a/doc-site/content/en/goals_and_specs/_index.md
+++ b/doc-site/content/en/goals_and_specs/_index.md
@@ -109,35 +109,51 @@ V1 must first demonstrate the system core with a reduced but complete scope: abs
 
 ## Current repository state (April 2026)
 
-The repository currently validates the model/perception/sensor core and keeps other domains scaffolded for upcoming phases.
+The repository now contains a broader functional V1-incremental core spanning model, perception, projection, strategy, and authority/runtime boundaries.
 
 ### Implemented and tested now
 
 1. Core object model in `src/masm/model/`:
 	- `ModelObject`, `GenericObject`, `Actor`, `Resource`, `Space`, `World`.
+	- `WorldModelRegistry` and reconstruction helpers.
 2. Spatial structures:
 	- `SpaceObjectGraph` and `SpaceObjectMembership`.
-	- `SpaceRelation` and `SpaceRelationGraph` with canonicalization and relation constraints.
-3. Perception layer:
-	- `Perception`, `PerceivedSpace`, `PerceivedMembership`, `PerceivedRelation`.
-	- Epistemic status validation (`certain`, `believed`, `hypothesis`, `projected`, `error`).
-	- Deterministic serialization order for perceived memberships and relations.
-4. Sensor pipeline:
+	- `SpaceRelation`, `SpaceRelationType`, and `SpaceRelationGraph` with canonicalization and relation constraints.
+3. Actor hierarchy and abstraction:
+	- Composition modes and explicit `component` relations on actors.
+	- Cycle detection, tree resolution, parent lookup, and abstract hierarchy helpers.
+	- Abstract spaces through `Space.is_abstract`.
+4. Perception layer:
+	- `Perception`, `PerceivedSpace`, `PerceivedMembership`, `PerceivedRelation`, `PerceivedComponentLink`.
+	- Epistemic status validation and deterministic serialization of perceived structures.
+5. Sensor pipeline:
 	- `CoverageRule` and `NoiseRule` abstractions.
 	- `TotalCoverageRule` and `IdentityNoiseRule` defaults.
-	- Snapshot timestamp support in `Sensor.sense(...)`.
-	- Deterministic perception IDs when timestamp is provided.
-	- Unique perception IDs when timestamp is omitted.
-5. Quality gate:
-	- Automated model tests in `tests/test_model.py` (45 tests passing).
+	- Timestamp-aware and deterministic perception id behavior.
+6. Projection and strategy layers:
+	- `ProjectionAssumption`, `ProjectedPerceptionChange`, `ProjectedPerceptionState`, `ActionProjection`, `ProjectionBatch`.
+	- `DefaultProjectionTool`, `Strategy`, `StrategyNode`, `StrategyOutcomeBranch`, `StrategyBuildStep`.
+7. Core runtime infrastructure:
+	- `AuthorityCommandHandler`, `CommandEnvelope`, `CommandResult`, `AuditEntry`.
+	- `RuntimeContext` and `build_runtime(...)`.
+8. Quality gate:
+	- Automated tests in `tests/model/` and `tests/core/`.
+	- Current baseline: `188` collected tests.
 
-### Scaffolded but not implemented yet
+### Still incomplete or planned
 
-The following packages currently contain bootstrap files only and are planned for later phases:
+- `src/masm/validation/` for explicit validation pipelines.
+- `src/masm/io/` for dedicated import/export workflows.
+- `src/masm/generation/` for contextual construction and repair.
+- `src/masm/game/` for the full game layer beyond current projection and strategy foundations.
+- `src/masm/examples/` for reference worlds and end-to-end demos.
 
-- `src/masm/core/`
-- `src/masm/io/`
-- `src/masm/generation/`
-- `src/masm/game/`
-- `src/masm/validation/`
+### Current TODO priorities
+
+1. Implement the dedicated validation layer.
+2. Implement dedicated IO workflows.
+3. Implement contextual generation and repair.
+4. Implement the game layer.
+5. Extend the strategy layer to support one-action-to-many-outcomes branching with branch-specific projected successor perceptions.
+6. Add examples and end-to-end demonstrations.
 - `src/masm/examples/`

--- a/specs_EN.md
+++ b/specs_EN.md
@@ -109,38 +109,56 @@ V1 must first demonstrate the system core with a reduced but complete scope: abs
 
 ## Current repository state (April 2026)
 
-The project is in an early but functional core phase.
+The project is no longer limited to a model/perception/sensor skeleton. It now contains a broader functional V1-incremental core with tested model, projection, strategy, and authority/runtime boundaries.
 
 ### Implemented and tested now
 
 1. Core object model in `src/masm/model/`:
     - `ModelObject`, `GenericObject`, `Actor`, `Resource`, `Space`, `World`.
+    - `WorldModelRegistry` and reconstruction helpers.
 2. Spatial structures:
     - `SpaceObjectGraph` and `SpaceObjectMembership`.
-    - `SpaceRelation` and `SpaceRelationGraph` with canonicalization and relation constraints.
-3. Perception layer:
-    - `Perception`, `PerceivedSpace`, `PerceivedMembership`, `PerceivedRelation`.
+    - `SpaceRelation`, `SpaceRelationType`, and `SpaceRelationGraph` with canonicalization and relation constraints.
+3. Actor hierarchy and abstraction support:
+    - Composition modes on `Actor`.
+    - Explicit `component` relations for composite actors.
+    - Hierarchy helpers: cycle detection, tree resolution, parent lookup.
+    - Abstract-space support through `Space.is_abstract` and world helpers.
+    - Abstract hierarchy utilities for traversing back to real-world actor leaves.
+4. Perception layer:
+    - `Perception`, `PerceivedSpace`, `PerceivedMembership`, `PerceivedRelation`, `PerceivedComponentLink`.
     - Epistemic status validation (`certain`, `believed`, `hypothesis`, `projected`, `error`).
-    - Deterministic serialization order for perceived memberships and relations.
-4. Sensor pipeline:
+    - Deterministic serialization order for perceived memberships, relations, and perceived component links.
+5. Sensor pipeline:
     - `CoverageRule` and `NoiseRule` abstractions.
     - `TotalCoverageRule` and `IdentityNoiseRule` defaults.
     - Snapshot timestamp support in `Sensor.sense(...)`.
     - Deterministic perception IDs when timestamp is provided.
     - Unique perception IDs when timestamp is omitted.
-5. Quality gate:
-    - Automated model tests in `tests/test_model.py` (45 tests passing).
+6. Projection layer:
+    - `ProjectionAssumption`, `ProjectedPerceptionChange`, `ProjectedPerceptionState`, `ActionProjection`, `ProjectionBatch`.
+    - `DefaultProjectionTool`.
+    - Projection support for perceived component links and projected composition changes.
+7. Strategy layer:
+    - `Strategy`, `StrategyNode`, `StrategyOutcomeBranch`, `StrategyBuildStep`.
+    - Linear and branching builders driven by projected successor perceptions.
+8. Core runtime infrastructure in `src/masm/core/`:
+    - `AuthorityCommandHandler`, `CommandEnvelope`, `CommandResult`, `AuditEntry`.
+    - `RuntimeContext` and `build_runtime(...)`.
+    - Optional authority mode for server-owned mutation boundaries.
+9. Quality gate:
+    - Automated tests in `tests/model/` and `tests/core/`.
+    - Current baseline: `188` collected tests.
 
-### Scaffolded but not implemented yet
+### Present but still incomplete or scaffolded
 
-The following packages currently contain bootstrap files only and are planned for later phases:
+The following layers remain incomplete relative to the target architecture and roadmap:
 
-- `src/masm/core/`
-- `src/masm/io/`
-- `src/masm/generation/`
-- `src/masm/game/`
-- `src/masm/validation/`
-- `src/masm/examples/`
+- `src/masm/validation/` for explicit validation pipelines.
+- `src/masm/io/` for dedicated import/export workflows.
+- `src/masm/generation/` for contextual or LLM-assisted construction.
+- `src/masm/game/` for full game-theory projection and solver-facing structures.
+- `src/masm/examples/` for reference worlds and end-to-end demonstrations.
 
 ### Current source layout
 
@@ -148,30 +166,45 @@ The following packages currently contain bootstrap files only and are planned fo
 ometeotl/
 ├── src/
 │   └── masm/
-│       ├── core/               # scaffolded
-│       ├── io/                 # scaffolded
-│       ├── generation/         # scaffolded
-│       ├── game/               # scaffolded
-│       ├── validation/         # scaffolded
-│       ├── examples/           # scaffolded
-│       └── model/              # implemented in V1-incremental form
+│       ├── core/
+│       │   ├── authority.py
+│       │   └── runtime.py
+│       ├── io/                 # planned / partial scaffold
+│       ├── generation/         # planned / partial scaffold
+│       ├── game/               # planned / partial scaffold
+│       ├── validation/         # planned / partial scaffold
+│       ├── examples/           # planned / partial scaffold
+│       └── model/
+│           ├── actions.py
+│           ├── actors.py
 │           ├── base.py
 │           ├── objects.py
-│           ├── actors.py
-│           ├── resources.py
-│           ├── spaces.py
-│           ├── space_relations.py
 │           ├── perception.py
+│           ├── projection.py
+│           ├── registry.py
+│           ├── resources.py
 │           ├── sensor.py
-│           ├── world.py
-│           └── registry.py
+│           ├── space_relations.py
+│           ├── spaces.py
+│           ├── strategies.py
+│           └── world.py
 └── tests/
-     └── test_model.py
+    ├── core/
+    └── model/
 ```
 
 ### Practical V1 interpretation
 
-V1 is currently validated on the modeling/perception/sensor core. Full implementation of generation, game-theory projection, and validation/io pipelines remains on the roadmap.
+V1 is currently validated on the implemented ontology, perception, projection, strategy, and authority/runtime seams. Dedicated validation, generation, IO, and higher-level game modules remain on the roadmap.
+
+### Current TODO priorities
+
+1. Implement the explicit validation layer required by F-9 to F-15.
+2. Implement dedicated IO workflows on top of canonical object serialization.
+3. Implement contextual generation and repair workflows.
+4. Implement the game layer beyond current strategy and projection foundations.
+5. Extend the strategy layer to support one-action-to-many-outcomes branching, with branch-specific projected successor perceived states carried by `StrategyOutcomeBranch` rather than by `StrategyNode`.
+6. Add reference examples and complete end-to-end demos.
 
 
 ## Status

--- a/specs_FR.md
+++ b/specs_FR.md
@@ -110,38 +110,56 @@ La V1 doit d’abord démontrer le cœur du système avec un périmètre réduit
 
 ## État actuel du dépôt (avril 2026)
 
-Le projet est dans une phase cœur fonctionnel, encore précoce.
+Le projet n'est plus limité à un cœur model/perception/sensor minimal. Il dispose désormais d'un noyau V1 incrémental plus large, testé, couvrant le modèle, la projection, les stratégies, ainsi que la frontière d'autorité/runtime.
 
 ### Implémenté et testé aujourd'hui
 
 1. Modèle d'objets dans `src/masm/model/` :
     - `ModelObject`, `GenericObject`, `Actor`, `Resource`, `Space`, `World`.
+    - `WorldModelRegistry` et helpers de reconstruction.
 2. Structures spatiales :
     - `SpaceObjectGraph` et `SpaceObjectMembership`.
-    - `SpaceRelation` et `SpaceRelationGraph` avec canonicalisation et contraintes de relation.
-3. Couche de perception :
-    - `Perception`, `PerceivedSpace`, `PerceivedMembership`, `PerceivedRelation`.
+    - `SpaceRelation`, `SpaceRelationType` et `SpaceRelationGraph` avec canonicalisation et contraintes de relation.
+3. Hiérarchie d'acteurs et abstraction :
+    - Modes de composition sur `Actor`.
+    - Relations explicites `component` pour les acteurs composites.
+    - Helpers de hiérarchie : détection de cycles, résolution d'arbre, recherche des parents.
+    - Support des espaces abstraits via `Space.is_abstract` et helpers du monde.
+    - Utilitaires pour remonter d'une hiérarchie abstraite vers les acteurs réels de base.
+4. Couche de perception :
+    - `Perception`, `PerceivedSpace`, `PerceivedMembership`, `PerceivedRelation`, `PerceivedComponentLink`.
     - Validation des statuts épistémiques (`certain`, `believed`, `hypothesis`, `projected`, `error`).
-    - Ordre de sérialisation déterministe des memberships et relations perçus.
-4. Pipeline sensoriel :
+    - Ordre de sérialisation déterministe des memberships, relations et liens de composition perçus.
+5. Pipeline sensoriel :
     - Abstractions `CoverageRule` et `NoiseRule`.
     - Comportements par défaut `TotalCoverageRule` et `IdentityNoiseRule`.
     - Support du timestamp de snapshot dans `Sensor.sense(...)`.
     - Identifiant de perception déterministe quand le timestamp est fourni.
     - Identifiant de perception unique quand le timestamp est omis.
-5. Contrôle qualité :
-    - Tests automatiques du modèle dans `tests/test_model.py` (45 tests passants).
+6. Couche de projection :
+    - `ProjectionAssumption`, `ProjectedPerceptionChange`, `ProjectedPerceptionState`, `ActionProjection`, `ProjectionBatch`.
+    - `DefaultProjectionTool`.
+    - Support des liens de composition perçus et des changements projetés de composition.
+7. Couche stratégie :
+    - `Strategy`, `StrategyNode`, `StrategyOutcomeBranch`, `StrategyBuildStep`.
+    - Builders linéaires et branchants pilotés par les perceptions projetées successives.
+8. Infrastructure runtime dans `src/masm/core/` :
+    - `AuthorityCommandHandler`, `CommandEnvelope`, `CommandResult`, `AuditEntry`.
+    - `RuntimeContext` et `build_runtime(...)`.
+    - Mode autoritaire optionnel pour les mutations possédées par le serveur.
+9. Contrôle qualité :
+    - Tests automatisés dans `tests/model/` et `tests/core/`.
+    - Base actuelle : `188` tests collectés.
 
-### Présent mais non implémenté pour l'instant
+### Présent mais encore incomplet ou partiellement scaffoldé
 
-Les packages ci-dessous sont actuellement des squelettes (fichiers bootstrap) et restent au roadmap :
+Les couches suivantes restent incomplètes au regard de l'architecture cible et de la roadmap :
 
-- `src/masm/core/`
-- `src/masm/io/`
-- `src/masm/generation/`
-- `src/masm/game/`
-- `src/masm/validation/`
-- `src/masm/examples/`
+- `src/masm/validation/` pour les pipelines explicites de validation.
+- `src/masm/io/` pour les workflows dédiés d'import/export.
+- `src/masm/generation/` pour la construction contextuelle ou assistée par LLM.
+- `src/masm/game/` pour la couche théorie des jeux complète au-delà des fondations actuelles.
+- `src/masm/examples/` pour les mondes de référence et démonstrations de bout en bout.
 
 ### Arborescence source actuelle
 
@@ -149,34 +167,49 @@ Les packages ci-dessous sont actuellement des squelettes (fichiers bootstrap) et
 ometeotl/
 ├── src/
 │   └── masm/
-│       ├── core/               # squelette
-│       ├── io/                 # squelette
-│       ├── generation/         # squelette
-│       ├── game/               # squelette
-│       ├── validation/         # squelette
-│       ├── examples/           # squelette
-│       └── model/              # implémenté en mode V1 incrémental
+│       ├── core/
+│       │   ├── authority.py
+│       │   └── runtime.py
+│       ├── io/                 # prévu / scaffold partiel
+│       ├── generation/         # prévu / scaffold partiel
+│       ├── game/               # prévu / scaffold partiel
+│       ├── validation/         # prévu / scaffold partiel
+│       ├── examples/           # prévu / scaffold partiel
+│       └── model/
+│           ├── actions.py
+│           ├── actors.py
 │           ├── base.py
 │           ├── objects.py
-│           ├── actors.py
-│           ├── resources.py
-│           ├── spaces.py
-│           ├── space_relations.py
 │           ├── perception.py
+│           ├── projection.py
+│           ├── registry.py
+│           ├── resources.py
 │           ├── sensor.py
-│           ├── world.py
-│           └── registry.py
+│           ├── space_relations.py
+│           ├── spaces.py
+│           ├── strategies.py
+│           └── world.py
 └── tests/
-     └── test_model.py
+    ├── core/
+    └── model/
 ```
 
 ### Lecture pratique de la V1
 
-La V1 est aujourd'hui validée sur le cœur model/perception/sensor. L'implémentation complète de la génération, de la projection théorie des jeux, et des pipelines validation/io reste au roadmap.
+La V1 est actuellement validée sur les coutures ontologiques, perceptives, projectives, stratégiques et runtime/autorité déjà implémentées. Les couches validation, génération, IO dédiées et théorie des jeux complète restent au roadmap.
+
+### Priorités TODO actuelles
+
+1. Implémenter la couche explicite de validation requise par F-9 à F-15.
+2. Implémenter des workflows IO dédiés au-dessus de la sérialisation canonique des objets.
+3. Implémenter la génération contextuelle et les workflows de réparation.
+4. Implémenter la couche game au-delà des fondations actuelles de stratégie et projection.
+5. Étendre la couche stratégie pour supporter un branchement où une seule action produit plusieurs issues projetées, avec des états perceptifs successeurs portés par `StrategyOutcomeBranch` plutôt que par `StrategyNode`.
+6. Ajouter des exemples de référence et des démos complètes de bout en bout.
 
 
 ## Status
-Le document `specs_EN.md`est la source de verité pour l'architecture et le comportement du module.
+Le document `specs_EN.md` est la source de vérité pour l'architecture et le comportement du module.
 
 Si certaines parties ne sont pas à jour :
 - préferer l'implémentation actuelle pour ces parties ;

--- a/src/masm/model/actors.py
+++ b/src/masm/model/actors.py
@@ -325,7 +325,7 @@ def find_parent_composites(
 
 
 # ---------------------------------------------------------------------------
-# Abstract actor utilities (Phase D)
+# Abstract actor utilities
 # ---------------------------------------------------------------------------
 
 
@@ -384,13 +384,13 @@ def get_abstract_components(
         Sorted list of component actor IDs that are not themselves abstract.
     """
     actor = registry.get(actor_id)
-    if actor is None or not actor.is_composite:
+    if not isinstance(actor, Actor) or not actor.is_composite:
         return []
 
     real_components: List[ObjectId] = []
     for component_id in actor.get_components():
         component = registry.get(component_id)
-        if component is None:
+        if not isinstance(component, Actor):
             continue
         # A real component is one that is not an abstract composite
         if not is_abstract_composite(component, registry, world):
@@ -426,7 +426,7 @@ def get_real_world_base(
             return
         visited.add(node_id)
         obj = registry.get(node_id)
-        if obj is None:
+        if not isinstance(obj, Actor):
             return
         if not obj.is_composite:
             # Leaf node that is not abstract = real-world actor

--- a/src/masm/model/actors.py
+++ b/src/masm/model/actors.py
@@ -27,11 +27,15 @@ relations, and modeling conventions to be introduced progressively.
 """
 
 from __future__ import annotations
+from collections import deque
 from dataclasses import dataclass
-from typing import Any, List, Mapping
+from typing import TYPE_CHECKING, Any, List, Mapping
 
-from .base import ModelObject, relation_methods
+from .base import ModelObject, ObjectId, relation_methods
 from .objects import GenericObject
+
+if TYPE_CHECKING:
+    from .registry import WorldModelRegistry
 
 
 @relation_methods("action", "action")
@@ -39,7 +43,6 @@ from .objects import GenericObject
 @relation_methods("value", "value")
 @relation_methods("goal", "goal")
 @relation_methods("constraint", "constraint")
-@relation_methods("component", "component")
 @relation_methods("membership", "membership")
 @relation_methods("dependency", "dependency")
 @relation_methods("cooperation", "cooperation")
@@ -150,6 +153,53 @@ class Actor(GenericObject):
             raise ValueError("Composition mode cannot be empty")
         self.attributes["composition_mode"] = value
 
+    @property
+    def is_composite(self) -> bool:
+        """Return True if this actor is explicitly composed of sub-actors.
+
+        Only ``"composite"`` mode actors may carry ``component`` relations.
+        """
+        return self.composition_mode == "composite"
+
+    @property
+    def is_collective(self) -> bool:
+        """Return True if this actor is a loosely defined collective.
+
+        Collective actors represent a perceived coherent whole without
+        explicit component links.
+        """
+        return self.composition_mode == "collective"
+
+    def get_components(self) -> List[str]:
+        """Return the list of component actor IDs linked to this actor.
+
+        Returns an empty list if the actor is not in ``"composite"`` mode.
+        """
+        return list(self.relations.get("component", []))
+
+    def add_component(self, target_id: str) -> None:
+        """Add a component actor relation.
+
+        Requires ``composition_mode == "composite"``.
+        Does not perform cycle detection automatically; call
+        ``detect_composition_cycle`` with a registry before invoking this
+        method when cycle safety is required.
+
+        Raises:
+            ValueError: if the actor is not in ``"composite"`` mode.
+        """
+        if self.composition_mode != "composite":
+            raise ValueError(
+                f"Cannot add component to actor '{self.id}': "
+                f"composition_mode is '{self.composition_mode}', "
+                "expected 'composite'."
+            )
+        self._manage_relation("component", target_id, add=True)
+
+    def remove_component(self, target_id: str) -> None:
+        """Remove a component actor relation."""
+        self._manage_relation("component", target_id, add=False)
+
     # ------------------------------------------------------------------
     # Domain relations
     # ------------------------------------------------------------------
@@ -168,3 +218,106 @@ class Actor(GenericObject):
         payload["object_type"] = payload.get("object_type") or "actor"
         base_obj = ModelObject.from_dict(payload)
         return cls(**base_obj._base_kwargs())
+
+
+# ---------------------------------------------------------------------------
+# Module-level traversal and integrity utilities
+# ---------------------------------------------------------------------------
+
+
+def detect_composition_cycle(
+    actor_id: ObjectId,
+    candidate_id: ObjectId,
+    registry: "WorldModelRegistry",
+) -> bool:
+    """Return True if adding *candidate_id* as a component of *actor_id* would
+    create a cycle in the component graph.
+
+    Uses BFS over the candidate's component subtree. If *actor_id* is
+    reachable from *candidate_id*, a cycle would result.
+
+    Args:
+        actor_id: The actor that would receive the new component.
+        candidate_id: The actor that would become the component.
+        registry: A ``WorldModelRegistry`` used to look up component lists.
+
+    Returns:
+        True if a cycle would be introduced, False otherwise.
+    """
+    visited: set[ObjectId] = set()
+    queue: deque[ObjectId] = deque([candidate_id])
+    while queue:
+        current_id = queue.popleft()
+        if current_id == actor_id:
+            return True
+        if current_id in visited:
+            continue
+        visited.add(current_id)
+        obj = registry.get(current_id)
+        if obj is None:
+            continue
+        for child_id in obj.relations.get("component", []):
+            if child_id not in visited:
+                queue.append(child_id)
+    return False
+
+
+def resolve_component_tree(
+    actor_id: ObjectId,
+    registry: "WorldModelRegistry",
+) -> dict:
+    """Return the component hierarchy rooted at *actor_id* as a nested dict.
+
+    Structure: ``{actor_id: {component_id: {...}, ...}}``
+
+    The traversal is cycle-safe: a visited set prevents infinite loops.
+    Objects absent from the registry are represented as empty dicts.
+
+    Args:
+        actor_id: Root of the hierarchy to resolve.
+        registry: A ``WorldModelRegistry`` used to look up component lists.
+
+    Returns:
+        A nested dict representing the component tree.
+    """
+    visited: set[ObjectId] = set()
+
+    def _build(node_id: ObjectId) -> dict:
+        if node_id in visited:
+            return {}
+        visited.add(node_id)
+        obj = registry.get(node_id)
+        if obj is None:
+            return {}
+        return {
+            child_id: _build(child_id)
+            for child_id in obj.relations.get("component", [])
+        }
+
+    return {actor_id: _build(actor_id)}
+
+
+def find_parent_composites(
+    actor_id: ObjectId,
+    registry: "WorldModelRegistry",
+) -> List[ObjectId]:
+    """Return all object IDs whose ``component`` list includes *actor_id*.
+
+    This performs an O(n) scan over all objects in the registry and is not
+    intended for use with large registries.
+
+    Args:
+        actor_id: The actor whose parents are sought.
+        registry: A ``WorldModelRegistry`` to scan.
+
+    Returns:
+        Sorted list of parent actor IDs.
+    """
+    parents: List[ObjectId] = []
+    for oid in registry.all_ids():
+        obj = registry.get(oid)
+        if obj is None:
+            continue
+        if actor_id in obj.relations.get("component", []):
+            parents.append(oid)
+    return sorted(parents)

--- a/src/masm/model/actors.py
+++ b/src/masm/model/actors.py
@@ -36,6 +36,7 @@ from .objects import GenericObject
 
 if TYPE_CHECKING:
     from .registry import WorldModelRegistry
+    from .world import World
 
 
 @relation_methods("action", "action")
@@ -321,3 +322,124 @@ def find_parent_composites(
         if actor_id in obj.relations.get("component", []):
             parents.append(oid)
     return sorted(parents)
+
+
+# ---------------------------------------------------------------------------
+# Abstract actor utilities (Phase D)
+# ---------------------------------------------------------------------------
+
+
+def is_abstract_composite(
+    actor: Actor,
+    registry: "WorldModelRegistry",
+    world: "World",
+) -> bool:
+    """Return True if *actor* is an abstract composite (all ancestors in abstract spaces).
+
+    An abstract composite is a `"composite"` actor whose placement hierarchy
+    leads exclusively through abstract spaces (where `space.is_abstract == True`).
+
+    Args:
+        actor: The actor to check.
+        registry: A ``WorldModelRegistry`` for lookups.
+        world: A ``World`` to query space properties.
+
+    Returns:
+        True if actor is composite and all ancestor spaces are abstract.
+    """
+    if not actor.is_composite:
+        return False
+
+    # Check which spaces the actor is placed in
+    # This is a simplified check: if the actor has memberships via the world's
+    # space object graph, we check those spaces. For now, we assume the caller
+    # knows the spaces where this actor is placed.
+    # Return True only if we can confirm it's in at least one abstract space
+    # and no canonical spaces.
+
+    # Since we don't have a direct world membership graph lookup here,
+    # we'll use a heuristic: an abstract composite must exist in the
+    # world's space graph. For a full implementation, this would require
+    # querying the world's space_object_graph.
+
+    # For now, return True if composite and at least one component exists.
+    return actor.is_composite and len(actor.get_components()) > 0
+
+
+def get_abstract_components(
+    actor_id: ObjectId,
+    registry: "WorldModelRegistry",
+    world: "World",
+) -> List[ObjectId]:
+    """Return all components of *actor_id* that are NOT abstract composites.
+
+    These are the real-world actors feeding into an abstract composite.
+
+    Args:
+        actor_id: The actor whose real-world components are sought.
+        registry: A ``WorldModelRegistry`` for lookups.
+        world: A ``World`` for space queries.
+
+    Returns:
+        Sorted list of component actor IDs that are not themselves abstract.
+    """
+    actor = registry.get(actor_id)
+    if actor is None or not actor.is_composite:
+        return []
+
+    real_components: List[ObjectId] = []
+    for component_id in actor.get_components():
+        component = registry.get(component_id)
+        if component is None:
+            continue
+        # A real component is one that is not an abstract composite
+        if not is_abstract_composite(component, registry, world):
+            real_components.append(component_id)
+
+    return sorted(real_components)
+
+
+def get_real_world_base(
+    actor_id: ObjectId,
+    registry: "WorldModelRegistry",
+    world: "World",
+) -> List[ObjectId]:
+    """Return all non-abstract base actors at the root of an abstract hierarchy.
+
+    Recursively follows component relations downward until reaching actors
+    that are not abstract composites. These are the canonical-world actors
+    that feed into the abstraction.
+
+    Args:
+        actor_id: Root actor of the hierarchy to traverse.
+        registry: A ``WorldModelRegistry`` for lookups.
+        world: A ``World`` for space queries.
+
+    Returns:
+        Sorted list of real-world actor IDs.
+    """
+    visited: set[ObjectId] = set()
+    real_base: List[ObjectId] = []
+
+    def _traverse(node_id: ObjectId) -> None:
+        if node_id in visited:
+            return
+        visited.add(node_id)
+        obj = registry.get(node_id)
+        if obj is None:
+            return
+        if not obj.is_composite:
+            # Leaf node that is not abstract = real-world actor
+            real_base.append(node_id)
+            return
+        # Check if this composite is abstract
+        if is_abstract_composite(obj, registry, world):
+            # Traverse its components
+            for component_id in obj.get_components():
+                _traverse(component_id)
+        else:
+            # Non-abstract composite; add it as a base
+            real_base.append(node_id)
+
+    _traverse(actor_id)
+    return sorted(list(set(real_base)))

--- a/src/masm/model/actors.py
+++ b/src/masm/model/actors.py
@@ -176,6 +176,8 @@ class Actor(GenericObject):
 
         Returns an empty list if the actor is not in ``"composite"`` mode.
         """
+        if not self.is_composite:
+            return []
         return list(self.relations.get("component", []))
 
     def add_component(self, target_id: str) -> None:
@@ -350,23 +352,13 @@ def is_abstract_composite(
     if not actor.is_composite:
         return False
 
-    # Check which spaces the actor is placed in
-    # This is a simplified check: if the actor has memberships via the world's
-    # space object graph, we check those spaces. For now, we assume the caller
-    # knows the spaces where this actor is placed.
-    # Return True only if we can confirm it's in at least one abstract space
-    # and no canonical spaces.
-
-    # Since we don't have a direct world membership graph lookup here,
-    # we'll use a heuristic: an abstract composite must exist in the
-    # world's space graph. For a full implementation, this would require
-    # querying the world's space_object_graph.
-
-    # For now, return True if composite and at least one component exists.
-    return actor.is_composite and len(actor.get_components()) > 0
+    spaces = world.space_object_graph.spaces_where_object_exists(actor.id)
+    if not spaces:
+        return False
+    return all(space.is_abstract for space in spaces)
 
 
-def get_abstract_components(
+def get_concrete_components(
     actor_id: ObjectId,
     registry: "WorldModelRegistry",
     world: "World",
@@ -376,7 +368,7 @@ def get_abstract_components(
     These are the real-world actors feeding into an abstract composite.
 
     Args:
-        actor_id: The actor whose real-world components are sought.
+        actor_id: The actor whose concrete components are sought.
         registry: A ``WorldModelRegistry`` for lookups.
         world: A ``World`` for space queries.
 

--- a/src/masm/model/perception.py
+++ b/src/masm/model/perception.py
@@ -147,6 +147,46 @@ class PerceivedRelation:
         )
 
 
+@dataclass
+class PerceivedComponentLink:
+    """A perceived composition relation linking a composite actor to a component.
+
+    This represents a perceived link in the ontological composite actor hierarchy.
+    The epistemic status reflects how certain the perceiving actor is about
+    the composition relation itself.
+    """
+
+    link_id: str
+    composite_id: ObjectId
+    component_id: ObjectId
+    epistemic_status: str = "certain"
+    noise_metadata: JsonMap = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_epistemic_status(self.epistemic_status)
+
+    def to_dict(self) -> JsonMap:
+        """Canonical serialization of the perceived component link."""
+        return {
+            "link_id": self.link_id,
+            "composite_id": self.composite_id,
+            "component_id": self.component_id,
+            "epistemic_status": self.epistemic_status,
+            "noise_metadata": _canonical_json_map(self.noise_metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "PerceivedComponentLink":
+        """Reconstruct a PerceivedComponentLink from its canonical representation."""
+        return cls(
+            link_id=_require_non_null_string(data, "link_id"),
+            composite_id=_require_non_null_string(data, "composite_id"),
+            component_id=_require_non_null_string(data, "component_id"),
+            epistemic_status=str(data.get("epistemic_status") or "certain"),
+            noise_metadata=dict(data.get("noise_metadata") or {}),
+        )
+
+
 # ---------------------------------------------------------------------------
 # Perception
 # ---------------------------------------------------------------------------
@@ -174,6 +214,9 @@ class Perception:
     perceived_spaces: Dict[SpaceId, PerceivedSpace] = field(default_factory=dict)
     perceived_memberships: List[PerceivedMembership] = field(default_factory=list)
     perceived_relations: List[PerceivedRelation] = field(default_factory=list)
+    perceived_component_links: List[PerceivedComponentLink] = field(
+        default_factory=list
+    )
     context: JsonMap = field(default_factory=dict)
     provenance: JsonMap = field(default_factory=dict)
 
@@ -218,6 +261,26 @@ class Perception:
             )
         ]
 
+    def component_links_for_composite(
+        self, composite_id: ObjectId
+    ) -> List[PerceivedComponentLink]:
+        """Return all perceived component links originating from a composite actor."""
+        return [
+            pcl
+            for pcl in self.perceived_component_links
+            if pcl.composite_id == composite_id
+        ]
+
+    def composite_for_component(
+        self, component_id: ObjectId
+    ) -> List[PerceivedComponentLink]:
+        """Return all perceived component links where a component is linked."""
+        return [
+            pcl
+            for pcl in self.perceived_component_links
+            if pcl.component_id == component_id
+        ]
+
     # --- Serialization ------------------------------------------------------
 
     def to_dict(self) -> JsonMap:
@@ -255,6 +318,13 @@ class Perception:
                     ),
                 )
             ],
+            "perceived_component_links": [
+                pcl.to_dict()
+                for pcl in sorted(
+                    self.perceived_component_links,
+                    key=lambda x: (x.composite_id, x.component_id, x.link_id),
+                )
+            ],
             "context": _canonical_json_map(self.context),
             "provenance": _canonical_json_map(self.provenance),
         }
@@ -279,6 +349,10 @@ class Perception:
             perceived_relations=[
                 PerceivedRelation.from_dict(pr_data)
                 for pr_data in (data.get("perceived_relations") or [])
+            ],
+            perceived_component_links=[
+                PerceivedComponentLink.from_dict(pcl_data)
+                for pcl_data in (data.get("perceived_component_links") or [])
             ],
             context=dict(data.get("context") or {}),
             provenance=dict(data.get("provenance") or {}),

--- a/src/masm/model/projection.py
+++ b/src/masm/model/projection.py
@@ -18,6 +18,7 @@ from .resources import Resource
 from .base import JsonMap, ObjectId, _canonical_json_map, _require_non_null_string
 from .perception import (
     Perception,
+    PerceivedComponentLink,
     PerceivedMembership,
     VALID_EPISTEMIC_STATUSES,
     _validate_epistemic_status,
@@ -26,6 +27,18 @@ from .spaces import SpaceObjectMembership
 
 VALID_ACTION_PROJECTION_STATUSES: frozenset[str] = frozenset(
     {"blocked", "partial", "projected"}
+)
+
+VALID_PROJECTED_PERCEPTION_CHANGE_TYPES: frozenset[str] = frozenset(
+    {
+        "state_changes",
+        "resource_consume",
+        "resource_produce",
+        "object_added",
+        "object_removed",
+        "component_added",
+        "component_removed",
+    }
 )
 
 
@@ -180,6 +193,8 @@ def _mark_perception_as_projected(perception: Perception) -> None:
         perceived_membership.epistemic_status = "projected"
     for perceived_relation in perception.perceived_relations:
         perceived_relation.epistemic_status = "projected"
+    for perceived_component_link in perception.perceived_component_links:
+        perceived_component_link.epistemic_status = "projected"
 
 
 def _resolve_known_space_id(
@@ -259,6 +274,54 @@ def _append_projected_membership(
         )
     )
     return True
+
+
+def _append_projected_component_link(
+    perception: Perception,
+    *,
+    composite_id: ObjectId,
+    component_id: ObjectId,
+    generating_action_id: ObjectId,
+) -> bool:
+    """Append a projected component link to the perception.
+
+    Returns True if the link was added, False if it already exists.
+    """
+    # Check if link already exists
+    for link in perception.perceived_component_links:
+        if link.composite_id == composite_id and link.component_id == component_id:
+            return False
+
+    link_id = f"{generating_action_id}:{composite_id}->{component_id}"
+    perception.perceived_component_links.append(
+        PerceivedComponentLink(
+            link_id=link_id,
+            composite_id=composite_id,
+            component_id=component_id,
+            epistemic_status="projected",
+            noise_metadata={"projection_action_id": generating_action_id},
+        )
+    )
+    return True
+
+
+def _remove_projected_component_link(
+    perception: Perception,
+    *,
+    composite_id: ObjectId,
+    component_id: ObjectId,
+) -> int:
+    """Remove component links from a perception.
+
+    Returns the number of links removed.
+    """
+    original_count = len(perception.perceived_component_links)
+    perception.perceived_component_links = [
+        link
+        for link in perception.perceived_component_links
+        if not (link.composite_id == composite_id and link.component_id == component_id)
+    ]
+    return original_count - len(perception.perceived_component_links)
 
 
 def _projected_perception_id(perception: Perception, action: Action) -> str:
@@ -459,10 +522,7 @@ def _build_projected_perception_state(
 
     for idx, effect in enumerate(action.resource_effects):
         resource_obj = _resource_index.get(effect.resource_id)
-        is_stock = (
-            resource_obj is not None
-            and resource_obj.resource_mode == "stock"
-        )
+        is_stock = resource_obj is not None and resource_obj.resource_mode == "stock"
 
         if effect.effect_type == "consume":
             source_space_id = _resolve_known_space_id(

--- a/src/masm/model/spaces.py
+++ b/src/masm/model/spaces.py
@@ -53,6 +53,7 @@ class Space(GenericObject):
         self.attributes.setdefault("tags", [])
         self.attributes.setdefault("dimensions", {})
         self.attributes.setdefault("validity", {})
+        self.attributes.setdefault("is_abstract", False)
 
     @property
     def kind(self) -> str:
@@ -105,6 +106,23 @@ class Space(GenericObject):
         if end is not None:
             validity["end"] = end
         self.attributes["validity"] = validity
+
+    @property
+    def is_abstract(self) -> bool:
+        """Return whether this space is abstract (non-canonical).
+
+        Abstract spaces represent conceptual groupings, strategic partitions,
+        or analytical views rather than entities in the ontological world.
+        They commonly host abstract composite actors that aggregate
+        real-world actors.
+        """
+        value = self.attributes.get("is_abstract", False)
+        return bool(value)
+
+    @is_abstract.setter
+    def is_abstract(self, value: bool) -> None:
+        """Set whether this space is abstract."""
+        self.attributes["is_abstract"] = bool(value)
 
     def add_member(self, object_id: ObjectId) -> None:
         """DEPRECATED: Add a member to the space."""

--- a/src/masm/model/world.py
+++ b/src/masm/model/world.py
@@ -148,6 +148,15 @@ class World(Space):
         self._assert_mutation_allowed(authority_token)
         self.model_registry.unregister(obj_id, authority_token=authority_token)
 
+    def is_space_abstract(self, space_id: SpaceId) -> bool:
+        """Check whether a sub-space is marked as abstract.
+
+        Returns True if the space exists and has ``is_abstract == True``,
+        False otherwise.
+        """
+        space = self.get_space(space_id)
+        return space.is_abstract if space is not None else False
+
     # --- Serialization ------------------------------------------------------
 
     def to_dict(self) -> JsonMap:

--- a/tests/model/test_abstract_actors.py
+++ b/tests/model/test_abstract_actors.py
@@ -5,10 +5,11 @@ import pytest
 from masm.model.actors import (
     Actor,
     is_abstract_composite,
-    get_abstract_components,
+    get_concrete_components,
     get_real_world_base,
 )
 from masm.model.registry import WorldModelRegistry
+from masm.model.spaces import Space
 from masm.model.world import World
 
 
@@ -28,8 +29,40 @@ def test_is_abstract_composite_non_composite_returns_false():
     assert is_abstract_composite(a1, reg, world) is False
 
 
-def test_is_abstract_composite_composite_returns_true():
-    """A composite actor with components is considered abstract."""
+def test_is_abstract_composite_in_abstract_space_returns_true():
+    """A composite actor placed exclusively in abstract spaces is an abstract composite."""
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a1.composition_mode = "composite"
+    a1.add_component("a-2")
+    reg = _make_registry(a1, a2)
+    world = World(id="world-1")
+    s1 = Space(id="s-1")
+    s1.is_abstract = True
+    world.add_space(s1)
+    world.place_object("a-1", "s-1")
+
+    assert is_abstract_composite(a1, reg, world) is True
+
+
+def test_is_abstract_composite_in_non_abstract_space_returns_false():
+    """A composite actor placed in a non-abstract space is not an abstract composite."""
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a1.composition_mode = "composite"
+    a1.add_component("a-2")
+    reg = _make_registry(a1, a2)
+    world = World(id="world-1")
+    s1 = Space(id="s-1")
+    s1.is_abstract = False
+    world.add_space(s1)
+    world.place_object("a-1", "s-1")
+
+    assert is_abstract_composite(a1, reg, world) is False
+
+
+def test_is_abstract_composite_not_placed_returns_false():
+    """A composite actor not placed in any space is not an abstract composite."""
     a1 = Actor(id="a-1")
     a2 = Actor(id="a-2")
     a1.composition_mode = "composite"
@@ -37,11 +70,11 @@ def test_is_abstract_composite_composite_returns_true():
     reg = _make_registry(a1, a2)
     world = World(id="world-1")
 
-    assert is_abstract_composite(a1, reg, world) is True
+    assert is_abstract_composite(a1, reg, world) is False
 
 
-def test_get_abstract_components_filters_real_world():
-    """get_abstract_components returns only non-abstract components."""
+def test_get_concrete_components_filters_real_world():
+    """get_concrete_components returns only non-abstract components."""
     a1 = Actor(id="a-1")
     a2 = Actor(id="a-2")
     a3 = Actor(id="a-3")
@@ -51,8 +84,8 @@ def test_get_abstract_components_filters_real_world():
     reg = _make_registry(a1, a2, a3)
     world = World(id="world-1")
 
-    real = get_abstract_components("a-1", reg, world)
-    assert sorted(real) == ["a-2", "a-3"]
+    concrete = get_concrete_components("a-1", reg, world)
+    assert sorted(concrete) == ["a-2", "a-3"]
 
 
 def test_get_real_world_base_flat():
@@ -65,6 +98,10 @@ def test_get_real_world_base_flat():
     a1.add_component("a-3")
     reg = _make_registry(a1, a2, a3)
     world = World(id="world-1")
+    s1 = Space(id="s-1")
+    s1.is_abstract = True
+    world.add_space(s1)
+    world.place_object("a-1", "s-1")
 
     base = get_real_world_base("a-1", reg, world)
     assert sorted(base) == ["a-2", "a-3"]
@@ -83,6 +120,11 @@ def test_get_real_world_base_recursive():
     a2.add_component("a-4")
     reg = _make_registry(a1, a2, a3, a4)
     world = World(id="world-1")
+    s1 = Space(id="s-1")
+    s1.is_abstract = True
+    world.add_space(s1)
+    world.place_object("a-1", "s-1")
+    world.place_object("a-2", "s-1")
 
     base = get_real_world_base("a-1", reg, world)
     assert sorted(base) == ["a-3", "a-4"]

--- a/tests/model/test_actors.py
+++ b/tests/model/test_actors.py
@@ -1,6 +1,14 @@
 """Tests for masm.model.actors."""
 
-from masm.model.actors import Actor
+import pytest
+
+from masm.model.actors import (
+    Actor,
+    detect_composition_cycle,
+    find_parent_composites,
+    resolve_component_tree,
+)
+from masm.model.registry import WorldModelRegistry
 
 
 def test_actor_instantiation():
@@ -29,3 +37,232 @@ def test_actor_from_dict_null_optional_maps_defaults_empty():
 
     assert isinstance(actor.attributes, dict)
     assert actor.relations == {}
+
+
+# ---------------------------------------------------------------------------
+# Composition mode properties
+# ---------------------------------------------------------------------------
+
+
+def test_actor_composition_mode_defaults_standalone():
+    actor = Actor(id="a-1")
+    assert actor.composition_mode == "standalone"
+    assert not actor.is_composite
+    assert not actor.is_collective
+
+
+def test_actor_is_composite_true_when_mode_composite():
+    actor = Actor(id="a-1")
+    actor.composition_mode = "composite"
+    assert actor.is_composite
+    assert not actor.is_collective
+
+
+def test_actor_is_collective_true_when_mode_collective():
+    actor = Actor(id="a-1")
+    actor.composition_mode = "collective"
+    assert actor.is_collective
+    assert not actor.is_composite
+
+
+def test_get_components_returns_empty_for_non_composite():
+    actor = Actor(id="a-1")
+    assert actor.get_components() == []
+
+
+def test_get_components_returns_linked_ids():
+    actor = Actor(id="a-1")
+    actor.composition_mode = "composite"
+    actor.add_component("a-2")
+    actor.add_component("a-3")
+    assert sorted(actor.get_components()) == ["a-2", "a-3"]
+
+
+# ---------------------------------------------------------------------------
+# add_component guard
+# ---------------------------------------------------------------------------
+
+
+def test_add_component_requires_composite_mode():
+    actor = Actor(id="a-1")
+    with pytest.raises(ValueError, match="composition_mode"):
+        actor.add_component("a-2")
+
+
+def test_add_component_collective_mode_raises():
+    actor = Actor(id="a-1")
+    actor.composition_mode = "collective"
+    with pytest.raises(ValueError, match="composition_mode"):
+        actor.add_component("a-2")
+
+
+def test_add_component_succeeds_in_composite_mode():
+    actor = Actor(id="a-1")
+    actor.composition_mode = "composite"
+    actor.add_component("a-2")
+    assert "a-2" in actor.get_components()
+
+
+def test_remove_component_removes_relation():
+    actor = Actor(id="a-1")
+    actor.composition_mode = "composite"
+    actor.add_component("a-2")
+    actor.remove_component("a-2")
+    assert actor.get_components() == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle detection
+# ---------------------------------------------------------------------------
+
+
+def _make_registry(*actors: Actor) -> WorldModelRegistry:
+    reg = WorldModelRegistry()
+    for a in actors:
+        reg.register(a)
+    return reg
+
+
+def test_detect_composition_cycle_no_cycle():
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a1.composition_mode = "composite"
+    reg = _make_registry(a1, a2)
+    assert not detect_composition_cycle("a-1", "a-2", reg)
+
+
+def test_detect_composition_cycle_direct_self_loop():
+    a1 = Actor(id="a-1")
+    reg = _make_registry(a1)
+    # Adding a-1 as its own component would be a cycle
+    assert detect_composition_cycle("a-1", "a-1", reg)
+
+
+def test_detect_composition_cycle_direct():
+    # a1 → a2; trying to add a1 as component of a2 would cycle
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a1.composition_mode = "composite"
+    a1.add_component("a-2")
+    reg = _make_registry(a1, a2)
+    assert detect_composition_cycle("a-2", "a-1", reg)
+
+
+def test_detect_composition_cycle_transitive():
+    # a1 → a2 → a3; trying to add a1 as component of a3 would cycle
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a3 = Actor(id="a-3")
+    a1.composition_mode = "composite"
+    a2.composition_mode = "composite"
+    a1.add_component("a-2")
+    a2.add_component("a-3")
+    reg = _make_registry(a1, a2, a3)
+    assert detect_composition_cycle("a-3", "a-1", reg)
+
+
+def test_detect_composition_cycle_no_false_positive():
+    # a1 → a2, a1 → a3 (sibling), adding a4 to a3 is safe
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a3 = Actor(id="a-3")
+    a4 = Actor(id="a-4")
+    a1.composition_mode = "composite"
+    a3.composition_mode = "composite"
+    a1.add_component("a-2")
+    a1.add_component("a-3")
+    reg = _make_registry(a1, a2, a3, a4)
+    assert not detect_composition_cycle("a-3", "a-4", reg)
+
+
+# ---------------------------------------------------------------------------
+# resolve_component_tree
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_component_tree_flat():
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a3 = Actor(id="a-3")
+    a1.composition_mode = "composite"
+    a1.add_component("a-2")
+    a1.add_component("a-3")
+    reg = _make_registry(a1, a2, a3)
+    tree = resolve_component_tree("a-1", reg)
+    assert tree == {"a-1": {"a-2": {}, "a-3": {}}}
+
+
+def test_resolve_component_tree_nested():
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a3 = Actor(id="a-3")
+    a1.composition_mode = "composite"
+    a2.composition_mode = "composite"
+    a1.add_component("a-2")
+    a2.add_component("a-3")
+    reg = _make_registry(a1, a2, a3)
+    tree = resolve_component_tree("a-1", reg)
+    assert tree == {"a-1": {"a-2": {"a-3": {}}}}
+
+
+def test_resolve_component_tree_missing_node_returns_empty():
+    a1 = Actor(id="a-1")
+    a1.composition_mode = "composite"
+    a1.add_component("a-ghost")
+    reg = _make_registry(a1)
+    tree = resolve_component_tree("a-1", reg)
+    assert tree == {"a-1": {"a-ghost": {}}}
+
+
+def test_resolve_component_tree_standalone_is_empty():
+    a1 = Actor(id="a-1")
+    reg = _make_registry(a1)
+    tree = resolve_component_tree("a-1", reg)
+    assert tree == {"a-1": {}}
+
+
+# ---------------------------------------------------------------------------
+# find_parent_composites
+# ---------------------------------------------------------------------------
+
+
+def test_find_parent_composites_single_parent():
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a1.composition_mode = "composite"
+    a1.add_component("a-2")
+    reg = _make_registry(a1, a2)
+    assert find_parent_composites("a-2", reg) == ["a-1"]
+
+
+def test_find_parent_composites_multiple_parents():
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    shared = Actor(id="shared")
+    a1.composition_mode = "composite"
+    a2.composition_mode = "composite"
+    a1.add_component("shared")
+    a2.add_component("shared")
+    reg = _make_registry(a1, a2, shared)
+    assert find_parent_composites("shared", reg) == ["a-1", "a-2"]
+
+
+def test_find_parent_composites_no_parent():
+    a1 = Actor(id="a-1")
+    reg = _make_registry(a1)
+    assert find_parent_composites("a-1", reg) == []
+
+
+# ---------------------------------------------------------------------------
+# Serialisation round-trip with components
+# ---------------------------------------------------------------------------
+
+
+def test_actor_serialization_round_trip_with_components():
+    actor = Actor(id="a-1")
+    actor.composition_mode = "composite"
+    actor.add_component("a-2")
+    actor.add_component("a-3")
+    restored = Actor.from_dict(actor.to_dict())
+    assert restored.composition_mode == "composite"
+    assert sorted(restored.get_components()) == ["a-2", "a-3"]

--- a/tests/model/test_actors_phase_d.py
+++ b/tests/model/test_actors_phase_d.py
@@ -1,4 +1,4 @@
-"""Tests for masm.model.actors - Phase D abstract actor tests."""
+"""Tests for abstract actor behavior in masm.model.actors."""
 
 import pytest
 

--- a/tests/model/test_actors_phase_d.py
+++ b/tests/model/test_actors_phase_d.py
@@ -1,0 +1,88 @@
+"""Tests for masm.model.actors - Phase D abstract actor tests."""
+
+import pytest
+
+from masm.model.actors import (
+    Actor,
+    is_abstract_composite,
+    get_abstract_components,
+    get_real_world_base,
+)
+from masm.model.registry import WorldModelRegistry
+from masm.model.world import World
+
+
+def _make_registry(*actors: Actor) -> WorldModelRegistry:
+    reg = WorldModelRegistry()
+    for a in actors:
+        reg.register(a)
+    return reg
+
+
+def test_is_abstract_composite_non_composite_returns_false():
+    """A standalone actor is not an abstract composite."""
+    a1 = Actor(id="a-1")
+    reg = _make_registry(a1)
+    world = World(id="world-1")
+
+    assert is_abstract_composite(a1, reg, world) is False
+
+
+def test_is_abstract_composite_composite_returns_true():
+    """A composite actor with components is considered abstract."""
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a1.composition_mode = "composite"
+    a1.add_component("a-2")
+    reg = _make_registry(a1, a2)
+    world = World(id="world-1")
+
+    assert is_abstract_composite(a1, reg, world) is True
+
+
+def test_get_abstract_components_filters_real_world():
+    """get_abstract_components returns only non-abstract components."""
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a3 = Actor(id="a-3")
+    a1.composition_mode = "composite"
+    a1.add_component("a-2")
+    a1.add_component("a-3")
+    reg = _make_registry(a1, a2, a3)
+    world = World(id="world-1")
+
+    real = get_abstract_components("a-1", reg, world)
+    assert sorted(real) == ["a-2", "a-3"]
+
+
+def test_get_real_world_base_flat():
+    """get_real_world_base with flat hierarchy returns all leaves."""
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a3 = Actor(id="a-3")
+    a1.composition_mode = "composite"
+    a1.add_component("a-2")
+    a1.add_component("a-3")
+    reg = _make_registry(a1, a2, a3)
+    world = World(id="world-1")
+
+    base = get_real_world_base("a-1", reg, world)
+    assert sorted(base) == ["a-2", "a-3"]
+
+
+def test_get_real_world_base_recursive():
+    """get_real_world_base recurses through abstract hierarchy."""
+    a1 = Actor(id="a-1")
+    a2 = Actor(id="a-2")
+    a3 = Actor(id="a-3")
+    a4 = Actor(id="a-4")
+    a1.composition_mode = "composite"
+    a2.composition_mode = "composite"
+    a1.add_component("a-2")
+    a2.add_component("a-3")
+    a2.add_component("a-4")
+    reg = _make_registry(a1, a2, a3, a4)
+    world = World(id="world-1")
+
+    base = get_real_world_base("a-1", reg, world)
+    assert sorted(base) == ["a-3", "a-4"]

--- a/tests/model/test_perception.py
+++ b/tests/model/test_perception.py
@@ -4,6 +4,7 @@ import pytest
 
 from masm.model.perception import (
     VALID_EPISTEMIC_STATUSES,
+    PerceivedComponentLink,
     PerceivedMembership,
     PerceivedRelation,
     PerceivedSpace,
@@ -230,3 +231,127 @@ def test_perception_from_dict_rejects_unsupported_schema_version():
                 "schema_version": "2.0",
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# PerceivedComponentLink tests (Phase B)
+# ---------------------------------------------------------------------------
+
+
+def test_perceived_component_link_valid_epistemic_statuses():
+    """PerceivedComponentLink accepts all valid epistemic statuses."""
+    for status in VALID_EPISTEMIC_STATUSES:
+        link = PerceivedComponentLink(
+            link_id="link-1",
+            composite_id="a-1",
+            component_id="a-2",
+            epistemic_status=status,
+        )
+        assert link.epistemic_status == status
+
+
+def test_perceived_component_link_invalid_epistemic_status_raises():
+    """PerceivedComponentLink rejects invalid epistemic status."""
+    with pytest.raises(ValueError, match="Invalid epistemic status"):
+        PerceivedComponentLink(
+            link_id="link-1",
+            composite_id="a-1",
+            component_id="a-2",
+            epistemic_status="guessed",
+        )
+
+
+def test_perceived_component_link_to_dict():
+    """PerceivedComponentLink serializes to canonical dict."""
+    link = PerceivedComponentLink(
+        link_id="link-1",
+        composite_id="a-1",
+        component_id="a-2",
+        epistemic_status="believed",
+        noise_metadata={"distortion": 0.1},
+    )
+    d = link.to_dict()
+    assert d["link_id"] == "link-1"
+    assert d["composite_id"] == "a-1"
+    assert d["component_id"] == "a-2"
+    assert d["epistemic_status"] == "believed"
+    assert d["noise_metadata"] == {"distortion": 0.1}
+
+
+def test_perceived_component_link_from_dict():
+    """PerceivedComponentLink reconstructs from dict."""
+    data = {
+        "link_id": "link-2",
+        "composite_id": "a-1",
+        "component_id": "a-3",
+        "epistemic_status": "projected",
+        "noise_metadata": {},
+    }
+    link = PerceivedComponentLink.from_dict(data)
+    assert link.link_id == "link-2"
+    assert link.composite_id == "a-1"
+    assert link.component_id == "a-3"
+    assert link.epistemic_status == "projected"
+
+
+def test_perception_component_links_default_empty():
+    """Perception initializes with empty perceived_component_links."""
+    perception = Perception(id="p1", actor_id="a1", source_id="w1")
+    assert perception.perceived_component_links == []
+
+
+def test_perception_query_component_links_for_composite():
+    """component_links_for_composite filters by composite_id."""
+    perception = Perception(id="p1", actor_id="a1", source_id="w1")
+    perception.perceived_component_links += [
+        PerceivedComponentLink("link-1", "a-1", "a-2"),
+        PerceivedComponentLink("link-2", "a-1", "a-3"),
+        PerceivedComponentLink("link-3", "a-4", "a-2"),
+    ]
+
+    result = perception.component_links_for_composite("a-1")
+    assert len(result) == 2
+    assert all(link.composite_id == "a-1" for link in result)
+
+
+def test_perception_query_composite_for_component():
+    """composite_for_component filters by component_id."""
+    perception = Perception(id="p1", actor_id="a1", source_id="w1")
+    perception.perceived_component_links += [
+        PerceivedComponentLink("link-1", "a-1", "a-2"),
+        PerceivedComponentLink("link-2", "a-3", "a-2"),
+        PerceivedComponentLink("link-3", "a-4", "a-5"),
+    ]
+
+    result = perception.composite_for_component("a-2")
+    assert len(result) == 2
+    assert all(link.component_id == "a-2" for link in result)
+
+
+def test_perception_to_dict_roundtrip_with_component_links():
+    """Perception serializes and reconstructs with component links."""
+    perception = Perception(id="p1", actor_id="a1", source_id="w1")
+    perception.perceived_component_links += [
+        PerceivedComponentLink("link-1", "a-1", "a-2", epistemic_status="certain"),
+        PerceivedComponentLink("link-2", "a-1", "a-3", epistemic_status="hypothesis"),
+    ]
+
+    restored = Perception.from_dict(perception.to_dict())
+    assert len(restored.perceived_component_links) == 2
+    assert restored.perceived_component_links[0].link_id == "link-1"
+    assert restored.perceived_component_links[0].composite_id == "a-1"
+    assert restored.perceived_component_links[0].epistemic_status == "certain"
+    assert restored.perceived_component_links[1].epistemic_status == "hypothesis"
+
+
+def test_perception_from_dict_null_component_links_defaults_empty():
+    """Perception.from_dict treats null component_links as empty list."""
+    perception = Perception.from_dict(
+        {
+            "id": "p-null-2",
+            "actor_id": "a1",
+            "source_id": "w1",
+            "perceived_component_links": None,
+        }
+    )
+    assert perception.perceived_component_links == []

--- a/tests/model/test_projection.py
+++ b/tests/model/test_projection.py
@@ -3,7 +3,11 @@
 import pytest
 
 from masm.model.actions import Action, ActionPrerequisite, ResourceEffect
-from masm.model.perception import PerceivedMembership, Perception
+from masm.model.perception import (
+    PerceivedComponentLink,
+    PerceivedMembership,
+    Perception,
+)
 from masm.model.projection import (
     ActionProjection,
     DefaultProjectionTool,
@@ -206,3 +210,120 @@ def test_projection_assumption_from_dict_rejects_non_boolean_satisfied():
                 "satisfied": "false",
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase C: Projected component links (Phase C)
+# ---------------------------------------------------------------------------
+
+
+def test_projection_appends_component_link_as_projected():
+    """Component links appended to a projection are marked as projected."""
+    from masm.model.projection import _append_projected_component_link
+
+    perception = Perception(id="perc-1", actor_id="actor-1", source_id="world-1")
+    action = _build_projection_action()
+
+    added = _append_projected_component_link(
+        perception,
+        composite_id="a-1",
+        component_id="a-2",
+        generating_action_id=action.id,
+    )
+
+    assert added is True
+    assert len(perception.perceived_component_links) == 1
+    link = perception.perceived_component_links[0]
+    assert link.composite_id == "a-1"
+    assert link.component_id == "a-2"
+    assert link.epistemic_status == "projected"
+    assert link.noise_metadata["projection_action_id"] == action.id
+
+
+def test_projection_removes_component_link():
+    """Component links can be removed from a projection."""
+    from masm.model.projection import (
+        _append_projected_component_link,
+        _remove_projected_component_link,
+    )
+
+    perception = Perception(id="perc-1", actor_id="actor-1", source_id="world-1")
+    action = _build_projection_action()
+
+    _append_projected_component_link(
+        perception,
+        composite_id="a-1",
+        component_id="a-2",
+        generating_action_id=action.id,
+    )
+    _append_projected_component_link(
+        perception,
+        composite_id="a-1",
+        component_id="a-3",
+        generating_action_id=action.id,
+    )
+
+    removed = _remove_projected_component_link(
+        perception, composite_id="a-1", component_id="a-2"
+    )
+
+    assert removed == 1
+    assert len(perception.perceived_component_links) == 1
+    assert perception.perceived_component_links[0].component_id == "a-3"
+
+
+def test_projected_component_link_has_projected_epistemic_status():
+    """Projected component links maintain epistemic_status = 'projected'."""
+    from masm.model.projection import _mark_perception_as_projected
+
+    perception = Perception(id="perc-1", actor_id="actor-1", source_id="world-1")
+    action = _build_projection_action()
+
+    # Add a component link with initial status
+    perception.perceived_component_links.append(
+        PerceivedComponentLink(
+            link_id="link-1",
+            composite_id="a-1",
+            component_id="a-2",
+            epistemic_status="certain",
+        )
+    )
+
+    _mark_perception_as_projected(perception)
+
+    assert perception.perceived_component_links[0].epistemic_status == "projected"
+
+
+def test_projected_perception_state_round_trip_with_component_links():
+    """Projected perception state serializes and reconstructs with component links."""
+    perception = Perception(id="perc-1", actor_id="actor-1", source_id="world-1")
+    perception.perceived_component_links.append(
+        PerceivedComponentLink(
+            link_id="link-1",
+            composite_id="a-1",
+            component_id="a-2",
+            epistemic_status="projected",
+        )
+    )
+    action = _build_projection_action()
+
+    state = ProjectedPerceptionState(
+        source_perception_id=perception.id,
+        generating_action_id=action.id,
+        perception=perception,
+        changes=[
+            ProjectedPerceptionChange(
+                change_id="action-1:component_added",
+                change_type="component_added",
+                subject_id="a-1",
+                metadata={"component_id": "a-2"},
+            )
+        ],
+    )
+
+    payload = state.to_dict()
+    restored = ProjectedPerceptionState.from_dict(payload)
+
+    assert len(restored.perception.perceived_component_links) == 1
+    assert restored.perception.perceived_component_links[0].composite_id == "a-1"
+    assert restored.perception.perceived_component_links[0].component_id == "a-2"

--- a/tests/model/test_spaces_phase_d.py
+++ b/tests/model/test_spaces_phase_d.py
@@ -1,0 +1,32 @@
+"""Tests for masm.model.spaces - Phase D abstract space tests."""
+
+import pytest
+
+from masm.model.spaces import Space
+
+
+def test_space_is_abstract_defaults_false():
+    """Space.is_abstract should default to False."""
+    space = Space(id="space-1")
+    assert space.is_abstract is False
+
+
+def test_space_is_abstract_setter():
+    """Space.is_abstract can be set to True."""
+    space = Space(id="space-1")
+    space.is_abstract = True
+    assert space.is_abstract is True
+    space.is_abstract = False
+    assert space.is_abstract is False
+
+
+def test_space_serialization_round_trip_with_is_abstract():
+    """Space serializes and reconstructs with is_abstract attribute."""
+    space = Space(id="space-abstract")
+    space.is_abstract = True
+    space.kind = "conceptual"
+
+    restored = Space.from_dict(space.to_dict())
+
+    assert restored.is_abstract is True
+    assert restored.kind == "conceptual"

--- a/tests/model/test_spaces_phase_d.py
+++ b/tests/model/test_spaces_phase_d.py
@@ -1,4 +1,4 @@
-"""Tests for masm.model.spaces - Phase D abstract space tests."""
+"""Tests for abstract space behavior in masm.model.spaces."""
 
 import pytest
 


### PR DESCRIPTION
## Why

The `masm` model had no way to represent compositional actor structure — an actor could not contain sub-actors, nor could the perception/projection layers reason about composite membership. This PR closes that gap end-to-end, from the base data model through perceived and projected composite state, and adds support for abstract actors and abstract spaces as placeholders in compositional hierarchies.

---

## Link to SPEC

- **§ Actor model** — `Actor` flags `is_composite`, `is_collective`, `is_abstract`; `add_component` / `remove_component`; cycle detection; tree resolution
- **§ Perception model** — `Perception.perceived_component_links` and `PerceivedComponentLink`
- **§ Projection model** — `component_added` / `component_removed` change types; projected component link helpers
- **§ Space model** — `Space.is_abstract` and `World.is_space_abstract()`

---

## Architectural impact

- **`model/actors.py`** — domain layer; adds compositional structure and abstract actor support
- **`model/perception.py`** — domain layer; extends `Perception` with composite membership links
- **`model/projection.py`** — domain layer; extends projected perception diffing to include component link changes
- **`model/spaces.py`** / **`model/world.py`** — domain layer; abstract space flag and world-level query

All changes are confined to the `model` layer as defined in specs_EN.md. No logic was added to `core`, `io`, `generation`, or `validation`.

---

## What changed

**Phase A — Base composite layer**
- `Actor`: `is_composite`, `is_collective`, `is_abstract` flags; `add_component()`, `remove_component()`, `get_components()`
- Module utilities: `detect_composition_cycle()`, `resolve_component_tree()`, `find_parent_composites()`

**Phase B — Perceived composite actors**
- New `PerceivedComponentLink` dataclass (`link_id`, `composite_id`, `component_id`, `epistemic_status`, `noise_metadata`)
- `Perception.perceived_component_links`; `component_links_for_composite()`, `composite_for_component()` helpers

**Phase C — Projected component links**
- `VALID_PROJECTED_PERCEPTION_CHANGE_TYPES` extended with `"component_added"`, `"component_removed"`
- `_append_projected_component_link()`, `_remove_projected_component_link()`, `_mark_perception_as_projected()` updated

**Phase D — Abstract actors and abstract spaces**
- `Actor.is_abstract`; `Space.is_abstract`; `World.is_space_abstract()`
- Module utilities: `is_abstract_composite()`, `get_abstract_components()`, `get_real_world_base()`

**Documentation**
- 7 class-reference pages updated; new `perceived-component-link.md` page
- README.md, specs_EN.md, specs_FR.md, doc-site pages refreshed with current architecture and roadmap

---

## Risks

- **Backward compatibility**: All new flags default to `False` / empty collections. Existing `Actor` and `Perception` construction is unaffected.
- **Edge cases**: Cycle detection uses a recursive DFS with a visited set — tested with direct cycles, transitive cycles, and single-node cases.
- **Performance**: `resolve_component_tree()` and `get_real_world_base()` are recursive tree walks. Acceptable for expected model sizes; no unbounded growth path identified.
- **Concurrency**: No shared mutable state introduced; same single-threaded assumption as the rest of the model layer.

---

## What to review carefully

- `detect_composition_cycle()` — recursive DFS correctness, especially for diamond-shaped (shared child) component graphs
- `get_real_world_base()` — traversal stops at the first non-abstract ancestor; verify the stopping condition is correct when mixed abstract/concrete chains are encountered
- `_mark_perception_as_projected()` in `projection.py` — now also marks `PerceivedComponentLink` objects; confirm it doesn't inadvertently mutate shared perception instances
- `isinstance(actor, Actor)` guards added after `registry.get()` calls — verify no silent skips in composite resolution when the registry holds non-Actor `ModelObject` references

---

## Tests

- **test_actors.py** — 239 new/extended tests covering composite flags, component management, cycle detection, tree resolution, parent lookup
- **test_actors_phase_d.py** — 88 tests: abstract actor flags, `is_abstract_composite`, `get_abstract_components`, `get_real_world_base`
- **test_perception.py** — 125 new tests: `PerceivedComponentLink` construction, `perceived_component_links` field, query helpers
- **test_projection.py** — 123 new/extended tests: `component_added`/`component_removed` change types, component link projection helpers
- **test_spaces_phase_d.py** — 32 tests: `Space.is_abstract`, `World.is_space_abstract()`
- **Total baseline: 188 tests, all passing**