### PR TITLE
Feature/llm export

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/ometeotl_core/generation/__init__.py
+++ b/src/ometeotl_core/generation/__init__.py
@@ -1,1 +1,15 @@
-# Core generation logic
+"""Contextual generation API for ometeotl_core."""
+
+from .context import GenerationContext, GenerationPlacement
+from .pipeline import ContextualGenerationPipeline, GenerationResult
+from .rules import GenerationRule, GenerationRuleSet, default_generation_rules
+
+__all__ = [
+	"GenerationContext",
+	"GenerationPlacement",
+	"GenerationResult",
+	"GenerationRule",
+	"GenerationRuleSet",
+	"ContextualGenerationPipeline",
+	"default_generation_rules",
+]

--- a/src/ometeotl_core/io/__init__.py
+++ b/src/ometeotl_core/io/__init__.py
@@ -15,6 +15,13 @@ from .importers import (
     world_from_mapping,
     world_from_yaml,
 )
+from .llm_export import (
+    LLMViewBuilder,
+    LLMViewContext,
+    actor_to_llm_view,
+    world_to_llm_view,
+    perception_to_llm_view,
+)
 
 __all__ = [
     "WorldImportResult",
@@ -28,4 +35,9 @@ __all__ = [
     "world_from_yaml",
     "read_world_json",
     "read_world_yaml",
+    "LLMViewBuilder",
+    "LLMViewContext",
+    "actor_to_llm_view",
+    "world_to_llm_view",
+    "perception_to_llm_view",
 ]

--- a/src/ometeotl_core/io/llm_export.py
+++ b/src/ometeotl_core/io/llm_export.py
@@ -227,15 +227,36 @@ class LLMViewBuilder:
             },
             "perceived_memberships": [
                 membership.to_dict()
-                for membership in getattr(perception, "perceived_memberships", [])
+                for membership in sorted(
+                    getattr(perception, "perceived_memberships", []),
+                    key=lambda x: (
+                        x.membership.space_id,
+                        x.membership.object_id,
+                        x.membership.role,
+                    ),
+                )
             ],
             "perceived_relations": [
                 relation.to_dict()
-                for relation in getattr(perception, "perceived_relations", [])
+                for relation in sorted(
+                    getattr(perception, "perceived_relations", []),
+                    key=lambda x: (
+                        x.relation.source_space_id,
+                        x.relation.target_space_id,
+                        x.relation.relation_type,
+                    ),
+                )
             ],
             "perceived_component_links": [
                 link.to_dict()
-                for link in getattr(perception, "perceived_component_links", [])
+                for link in sorted(
+                    getattr(perception, "perceived_component_links", []),
+                    key=lambda x: (
+                        x.composite_id,
+                        x.component_id,
+                        x.link_id,
+                    ),
+                )
             ],
         }
 
@@ -243,12 +264,21 @@ class LLMViewBuilder:
         """Group perceived items by epistemic status for stable LLM output."""
         grouped: dict[str, list[dict[str, Any]]] = {}
 
-        for space_id, space_view in getattr(perception, "perceived_spaces", {}).items():
+        for space_id, space_view in sorted(
+            getattr(perception, "perceived_spaces", {}).items()
+        ):
             grouped.setdefault(space_view.epistemic_status, []).append(
                 {"kind": "space", "id": space_id}
             )
 
-        for membership in getattr(perception, "perceived_memberships", []):
+        for membership in sorted(
+            getattr(perception, "perceived_memberships", []),
+            key=lambda x: (
+                x.membership.space_id,
+                x.membership.object_id,
+                x.membership.role,
+            ),
+        ):
             grouped.setdefault(membership.epistemic_status, []).append(
                 {
                     "kind": "membership",
@@ -257,7 +287,14 @@ class LLMViewBuilder:
                 }
             )
 
-        for relation in getattr(perception, "perceived_relations", []):
+        for relation in sorted(
+            getattr(perception, "perceived_relations", []),
+            key=lambda x: (
+                x.relation.source_space_id,
+                x.relation.target_space_id,
+                x.relation.relation_type,
+            ),
+        ):
             grouped.setdefault(relation.epistemic_status, []).append(
                 {
                     "kind": "relation",
@@ -266,7 +303,14 @@ class LLMViewBuilder:
                 }
             )
 
-        for link in getattr(perception, "perceived_component_links", []):
+        for link in sorted(
+            getattr(perception, "perceived_component_links", []),
+            key=lambda x: (
+                x.composite_id,
+                x.component_id,
+                x.link_id,
+            ),
+        ):
             grouped.setdefault(link.epistemic_status, []).append(
                 {
                     "kind": "component_link",
@@ -275,7 +319,10 @@ class LLMViewBuilder:
                 }
             )
 
-        return grouped
+        return {
+            status: grouped[status]
+            for status in sorted(grouped)
+        }
 
     def world_view(
         self,
@@ -343,11 +390,15 @@ class LLMViewBuilder:
                 1 for obj in registered_objects if obj.object_type == "resource"
             )
 
-            actors = [obj.id for obj in registered_objects if obj.object_type == "actor"]
-            spaces = [obj.id for obj in registered_objects if obj.object_type == "space"]
-            resources = [
+            actors = sorted(
+                obj.id for obj in registered_objects if obj.object_type == "actor"
+            )
+            spaces = sorted(
+                obj.id for obj in registered_objects if obj.object_type == "space"
+            )
+            resources = sorted(
                 obj.id for obj in registered_objects if obj.object_type == "resource"
-            ]
+            )
 
             # Include member IDs
             view["members"] = {

--- a/src/ometeotl_core/io/llm_export.py
+++ b/src/ometeotl_core/io/llm_export.py
@@ -138,6 +138,145 @@ class LLMViewBuilder:
 
         return view
 
+    def _build_reality_block(
+        self,
+        data: Mapping[str, Any],
+        context: LLMViewContext,
+    ) -> dict[str, Any]:
+        """Build the ontological slice of a model object."""
+        reality: dict[str, Any] = {}
+
+        if context.include_attributes:
+            attributes = data.get("attributes", {})
+            if attributes:
+                reality["attributes"] = dict(attributes)
+
+        if context.include_state:
+            state = data.get("state", {})
+            if state:
+                reality["state"] = dict(state)
+
+        if context.include_relations:
+            relations = data.get("relations", {})
+            if relations:
+                reality["relations"] = {
+                    key: sorted(str(rel_id) for rel_id in rel_ids)
+                    for key, rel_ids in relations.items()
+                    if rel_ids
+                }
+
+        if context.include_provenance:
+            provenance = data.get("provenance", {})
+            if provenance:
+                reality["provenance"] = dict(provenance)
+
+        if context.include_context:
+            ctx = data.get("context", {})
+            if ctx:
+                reality["context"] = dict(ctx)
+
+        return reality
+
+    def _build_epistemic_block(
+        self,
+        status: str,
+        meaning: str,
+        has_perception: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "status": status,
+            "meaning": meaning,
+            "distinctions": [
+                "reality",
+                "perception",
+                "belief",
+                "hypothesis",
+                "projection",
+            ],
+            "has_perception": has_perception,
+        }
+
+    def _attach_standard_blocks(
+        self,
+        view: dict[str, Any],
+        *,
+        reality: Mapping[str, Any],
+        epistemic_status: str,
+        epistemic_meaning: str,
+        has_perception: bool = False,
+        perception: Any = None,
+    ) -> dict[str, Any]:
+        """Attach the standard LLM blocks to a view and return it."""
+        view["reality"] = dict(reality)
+        view["perception"] = perception
+        view["epistemic"] = self._build_epistemic_block(
+            status=epistemic_status,
+            meaning=epistemic_meaning,
+            has_perception=has_perception,
+        )
+        return view
+
+    def _build_perception_payload(self, perception: Any) -> dict[str, Any]:
+        """Build the raw perceived structures for LLM consumption."""
+        return {
+            "perceived_spaces": {
+                space_id: space_view.to_dict()
+                for space_id, space_view in sorted(
+                    getattr(perception, "perceived_spaces", {}).items()
+                )
+            },
+            "perceived_memberships": [
+                membership.to_dict()
+                for membership in getattr(perception, "perceived_memberships", [])
+            ],
+            "perceived_relations": [
+                relation.to_dict()
+                for relation in getattr(perception, "perceived_relations", [])
+            ],
+            "perceived_component_links": [
+                link.to_dict()
+                for link in getattr(perception, "perceived_component_links", [])
+            ],
+        }
+
+    def _build_epistemic_status_groups(self, perception: Any) -> dict[str, list[dict[str, Any]]]:
+        """Group perceived items by epistemic status for stable LLM output."""
+        grouped: dict[str, list[dict[str, Any]]] = {}
+
+        for space_id, space_view in getattr(perception, "perceived_spaces", {}).items():
+            grouped.setdefault(space_view.epistemic_status, []).append(
+                {"kind": "space", "id": space_id}
+            )
+
+        for membership in getattr(perception, "perceived_memberships", []):
+            grouped.setdefault(membership.epistemic_status, []).append(
+                {
+                    "kind": "membership",
+                    "object_id": membership.membership.object_id,
+                    "space_id": membership.membership.space_id,
+                }
+            )
+
+        for relation in getattr(perception, "perceived_relations", []):
+            grouped.setdefault(relation.epistemic_status, []).append(
+                {
+                    "kind": "relation",
+                    "source_space_id": relation.relation.source_space_id,
+                    "target_space_id": relation.relation.target_space_id,
+                }
+            )
+
+        for link in getattr(perception, "perceived_component_links", []):
+            grouped.setdefault(link.epistemic_status, []).append(
+                {
+                    "kind": "component_link",
+                    "composite_id": link.composite_id,
+                    "component_id": link.component_id,
+                }
+            )
+
+        return grouped
+
     def world_view(
         self,
         world: Any,
@@ -169,6 +308,12 @@ class LLMViewBuilder:
             "world",
             world_dict,
             context,
+        )
+        self._attach_standard_blocks(
+            view,
+            reality=self._build_reality_block(world_dict, context),
+            epistemic_status="certain",
+            epistemic_meaning="Ontological world state",
         )
 
         # Add member objects summary
@@ -249,6 +394,23 @@ class LLMViewBuilder:
             actor_dict,
             context,
         )
+        perception_view = (
+            self.perception_view(include_perception, context)
+            if include_perception is not None
+            else None
+        )
+        self._attach_standard_blocks(
+            view,
+            reality=self._build_reality_block(actor_dict, context),
+            epistemic_status="mixed" if include_perception is not None else "certain",
+            epistemic_meaning=(
+                "Actor reality plus an attached perception view"
+                if include_perception is not None
+                else "Ontological actor state"
+            ),
+            has_perception=include_perception is not None,
+            perception=perception_view,
+        )
 
         # Expose key actor properties
         kind = actor.attributes.get("kind", "generic")
@@ -266,10 +428,6 @@ class LLMViewBuilder:
                 "values": relations.get("value", []),
             }
             view["constraints"] = relations.get("constraint", [])
-
-        # If perception is provided, include the actor's view of the world
-        if include_perception is not None:
-            view["perception"] = self.perception_view(include_perception, context)
 
         return view
 
@@ -304,6 +462,12 @@ class LLMViewBuilder:
             "strategy",
             strategy_dict,
             context,
+        )
+        self._attach_standard_blocks(
+            view,
+            reality=self._build_reality_block(strategy_dict, context),
+            epistemic_status="certain",
+            epistemic_meaning="Ontological strategy structure",
         )
 
         # Highlight strategy structure
@@ -348,6 +512,12 @@ class LLMViewBuilder:
             goal_dict,
             context,
         )
+        self._attach_standard_blocks(
+            view,
+            reality=self._build_reality_block(goal_dict, context),
+            epistemic_status="certain",
+            epistemic_meaning="Ontological goal structure",
+        )
 
         if context.include_relations:
             relations = goal_dict.get("relations", {})
@@ -391,19 +561,23 @@ class LLMViewBuilder:
             perception_dict,
             context,
         )
+        perception_payload = self._build_perception_payload(perception)
 
-        # Highlight epistemic structure
-        perceived_items = perception_dict.get("perceived_items", {})
-        view["epistemic_statuses"] = {}
+        self._attach_standard_blocks(
+            view,
+            reality={
+                "id": perception.id,
+                "actor_id": perception_dict.get("actor_id"),
+                "source_id": perception_dict.get("source_id"),
+                "timestamp": perception_dict.get("timestamp"),
+            },
+            epistemic_status="mixed",
+            epistemic_meaning="Perception groups reality into epistemic confidence levels",
+            has_perception=True,
+            perception=perception_payload,
+        )
 
-        # Count items by epistemic status
-        for item_id, item_data in perceived_items.items():
-            status = item_data.get("epistemic_status", "certain")
-            if status not in view["epistemic_statuses"]:
-                view["epistemic_statuses"][status] = []
-            view["epistemic_statuses"][status].append(item_id)
-
-        # Add interpretation guide
+        view["epistemic_statuses"] = self._build_epistemic_status_groups(perception)
         view["epistemic_meanings"] = {
             "certain": "Directly observed, no uncertainty",
             "believed": "Inferred or remembered, probably true",
@@ -411,7 +585,6 @@ class LLMViewBuilder:
             "projected": "Anticipated based on a model but not observed",
             "error": "Identified as incorrect (diagnosed hallucination)",
         }
-
         return view
 
     def space_view(
@@ -445,6 +618,12 @@ class LLMViewBuilder:
             "space",
             space_dict,
             context,
+        )
+        self._attach_standard_blocks(
+            view,
+            reality=self._build_reality_block(space_dict, context),
+            epistemic_status="certain",
+            epistemic_meaning="Ontological space state",
         )
 
         # Highlight space properties

--- a/src/ometeotl_core/io/llm_export.py
+++ b/src/ometeotl_core/io/llm_export.py
@@ -1,0 +1,522 @@
+"""LLM-oriented export for model objects.
+
+This module provides utilities to convert model objects into views optimized
+for consumption by language models, clearly distinguishing:
+- reality (ontological state)
+- perception (actor-specific views)
+- epistemic status (certain, believed, hypothesis, projected, error)
+
+Requirement F-5: A dedicated language-model view must explicitly distinguish
+reality, perception, belief, hypothesis, and projection.
+
+Axioms A-9, A-10: Each actor has partial, biased perception; decisions depend
+on perception, not ontological reality.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Set, Optional
+from dataclasses import dataclass, field
+
+
+@dataclass
+class LLMViewContext:
+    """Context for building LLM views, tracking circular references and options.
+
+    Attributes:
+        include_provenance: Include provenance metadata in output.
+        include_context: Include context metadata in output.
+        include_state: Include dynamic state in output.
+        include_relations: Include relations to other objects (as IDs).
+        include_attributes: Include descriptive attributes in output.
+        seen_ids: Set of already-visited object IDs (for cycle detection).
+        reference_style: How to handle cross-references: "id" (object IDs),
+            "path" (hierarchical path), or "full" (inline object if not circular).
+    """
+
+    include_provenance: bool = False
+    include_context: bool = False
+    include_state: bool = True
+    include_relations: bool = True
+    include_attributes: bool = True
+    seen_ids: Set[str] = field(default_factory=set)
+    reference_style: str = "id"  # "id", "path", or "full"
+
+    def copy(self) -> LLMViewContext:
+        """Create a shallow copy of this context (seen_ids is shared)."""
+        return LLMViewContext(
+            include_provenance=self.include_provenance,
+            include_context=self.include_context,
+            include_state=self.include_state,
+            include_relations=self.include_relations,
+            include_attributes=self.include_attributes,
+            seen_ids=self.seen_ids,
+            reference_style=self.reference_style,
+        )
+
+    def mark_visited(self, obj_id: str) -> None:
+        """Record that we've visited an object (for cycle detection)."""
+        self.seen_ids.add(obj_id)
+
+    def is_visited(self, obj_id: str) -> bool:
+        """Check if an object has been visited."""
+        return obj_id in self.seen_ids
+
+
+class LLMViewBuilder:
+    """Builder for language-model-oriented views of model objects.
+
+    Converts model objects to structured dictionaries optimized for LLM
+    consumption, emphasizing:
+    - Epistemic clarity (certain vs. believed vs. hypothesis vs. projected vs. error)
+    - Reality/perception separation
+    - Deterministic structure
+    - Explicit handling of circular references
+
+    Usage:
+        builder = LLMViewBuilder()
+        view = builder.world_view(world, context=LLMViewContext())
+    """
+
+    def __init__(self) -> None:
+        """Initialize the builder."""
+        # Stateless builder; all export settings live in LLMViewContext.
+        return
+
+    def _build_base_view(
+        self,
+        obj_id: str,
+        obj_type: str,
+        data: Mapping[str, Any],
+        context: LLMViewContext,
+    ) -> dict[str, Any]:
+        """Build the base view structure for any model object.
+
+        Args:
+            obj_id: The object's unique identifier.
+            obj_type: The canonical type of the object (e.g., "actor", "world").
+            data: The object's data (attributes, relations, state, etc.).
+            context: LLMViewContext controlling what to include.
+
+        Returns:
+            A dictionary with id, type, and optionally attributes, state, relations.
+        """
+        view: dict[str, Any] = {
+            "id": obj_id,
+            "type": obj_type,
+        }
+
+        if context.include_attributes:
+            attributes = data.get("attributes", {})
+            if attributes:
+                view["attributes"] = dict(attributes)
+
+        if context.include_state:
+            state = data.get("state", {})
+            if state:
+                view["state"] = dict(state)
+
+        if context.include_relations:
+            relations = data.get("relations", {})
+            if relations:
+                # Format relations as ID references
+                view["relations"] = {
+                    key: sorted(str(rel_id) for rel_id in rel_ids)
+                    for key, rel_ids in relations.items()
+                    if rel_ids
+                }
+
+        if context.include_provenance:
+            provenance = data.get("provenance", {})
+            if provenance:
+                view["provenance"] = dict(provenance)
+
+        if context.include_context:
+            ctx = data.get("context", {})
+            if ctx:
+                view["context"] = dict(ctx)
+
+        return view
+
+    def world_view(
+        self,
+        world: Any,
+        context: Optional[LLMViewContext] = None,
+    ) -> dict[str, Any]:
+        """Build an LLM view of a World object.
+
+        The view includes:
+        - World metadata (id, type, attributes)
+        - Member objects (actors, spaces, resources) as ID references
+        - World state and relations
+        - Space hierarchy
+
+        Args:
+            world: The World object (expects to_dict() and model_registry).
+            context: LLMViewContext controlling output. Defaults to sensible LLM-friendly defaults.
+
+        Returns:
+            A dictionary suitable for LLM consumption.
+        """
+        if context is None:
+            context = LLMViewContext()
+
+        context.mark_visited(world.id)
+
+        world_dict = world.to_dict()
+        view = self._build_base_view(
+            world.id,
+            "world",
+            world_dict,
+            context,
+        )
+
+        # Add member objects summary
+        members_summary = {
+            "total_actors": 0,
+            "total_spaces": 0,
+            "total_resources": 0,
+        }
+
+        if hasattr(world, "model_registry") and world.model_registry:
+            registry = world.model_registry
+            registered_objects = [
+                registry.get(obj_id)
+                for obj_id in registry.all_ids()
+            ]
+            registered_objects = [
+                obj for obj in registered_objects if obj is not None
+            ]
+
+            members_summary["total_actors"] = sum(
+                1 for obj in registered_objects if obj.object_type == "actor"
+            )
+            members_summary["total_spaces"] = sum(
+                1 for obj in registered_objects if obj.object_type == "space"
+            )
+            members_summary["total_resources"] = sum(
+                1 for obj in registered_objects if obj.object_type == "resource"
+            )
+
+            actors = [obj.id for obj in registered_objects if obj.object_type == "actor"]
+            spaces = [obj.id for obj in registered_objects if obj.object_type == "space"]
+            resources = [
+                obj.id for obj in registered_objects if obj.object_type == "resource"
+            ]
+
+            # Include member IDs
+            view["members"] = {
+                "actors": actors,
+                "spaces": spaces,
+                "resources": resources,
+            }
+
+        view["members_summary"] = members_summary
+
+        return view
+
+    def actor_view(
+        self,
+        actor: Any,
+        context: Optional[LLMViewContext] = None,
+        include_perception: Optional[Any] = None,
+    ) -> dict[str, Any]:
+        """Build an LLM view of an Actor object.
+
+        The view includes:
+        - Actor metadata (id, type, kind, attributes)
+        - Actor's capabilities (actions, resources)
+        - Actor's objectives (goals, values, constraints)
+        - Optional: Actor's perception (if provided)
+
+        Args:
+            actor: The Actor object.
+            context: LLMViewContext controlling output.
+            include_perception: Optional Perception object for this actor.
+
+        Returns:
+            A dictionary suitable for LLM consumption.
+        """
+        if context is None:
+            context = LLMViewContext()
+
+        context.mark_visited(actor.id)
+
+        actor_dict = actor.to_dict()
+        view = self._build_base_view(
+            actor.id,
+            "actor",
+            actor_dict,
+            context,
+        )
+
+        # Expose key actor properties
+        kind = actor.attributes.get("kind", "generic")
+        view["kind"] = str(kind)
+
+        # Highlight key relations for actors
+        if context.include_relations:
+            relations = actor_dict.get("relations", {})
+            view["capabilities"] = {
+                "actions": relations.get("action", []),
+                "resources": relations.get("resource", []),
+            }
+            view["objectives"] = {
+                "goals": relations.get("goal", []),
+                "values": relations.get("value", []),
+            }
+            view["constraints"] = relations.get("constraint", [])
+
+        # If perception is provided, include the actor's view of the world
+        if include_perception is not None:
+            view["perception"] = self.perception_view(include_perception, context)
+
+        return view
+
+    def strategy_view(
+        self,
+        strategy: Any,
+        context: Optional[LLMViewContext] = None,
+    ) -> dict[str, Any]:
+        """Build an LLM view of a Strategy object.
+
+        The view includes:
+        - Strategy metadata (id, type)
+        - Action being modeled
+        - Projected outcomes and branch information
+        - Uncertainty/risk assessment
+
+        Args:
+            strategy: The Strategy object.
+            context: LLMViewContext controlling output.
+
+        Returns:
+            A dictionary suitable for LLM consumption.
+        """
+        if context is None:
+            context = LLMViewContext()
+
+        context.mark_visited(strategy.id)
+
+        strategy_dict = strategy.to_dict()
+        view = self._build_base_view(
+            strategy.id,
+            "strategy",
+            strategy_dict,
+            context,
+        )
+
+        # Highlight strategy structure
+        if context.include_relations:
+            relations = strategy_dict.get("relations", {})
+            view["structure"] = {
+                "action": relations.get("action", []),
+                "outcome_branches": relations.get("outcome_branch", []),
+                "assumptions": relations.get("projection_assumption", []),
+            }
+
+        return view
+
+    def goal_view(
+        self,
+        goal: Any,
+        context: Optional[LLMViewContext] = None,
+    ) -> dict[str, Any]:
+        """Build an LLM view of a Goal object.
+
+        The view includes:
+        - Goal metadata (id, type)
+        - Goal description and scope
+        - Goal's relation to actor and target space
+
+        Args:
+            goal: The Goal object.
+            context: LLMViewContext controlling output.
+
+        Returns:
+            A dictionary suitable for LLM consumption.
+        """
+        if context is None:
+            context = LLMViewContext()
+
+        context.mark_visited(goal.id)
+
+        goal_dict = goal.to_dict()
+        view = self._build_base_view(
+            goal.id,
+            "goal",
+            goal_dict,
+            context,
+        )
+
+        if context.include_relations:
+            relations = goal_dict.get("relations", {})
+            view["structure"] = {
+                "actor": relations.get("actor", []),
+                "target_space": relations.get("target_space", []),
+                "related_goals": relations.get("parent_goal", []),
+            }
+
+        return view
+
+    def perception_view(
+        self,
+        perception: Any,
+        context: Optional[LLMViewContext] = None,
+    ) -> dict[str, Any]:
+        """Build an LLM view of a Perception object.
+
+        The view includes:
+        - Epistemic status markers (certain, believed, hypothesis, projected, error)
+        - Perceived spaces, memberships, relations
+        - Perceived component links (for composite actors)
+        - Noise/distortion metadata
+
+        Args:
+            perception: The Perception object.
+            context: LLMViewContext controlling output.
+
+        Returns:
+            A dictionary suitable for LLM consumption.
+        """
+        if context is None:
+            context = LLMViewContext()
+
+        context.mark_visited(perception.id)
+
+        perception_dict = perception.to_dict()
+        view = self._build_base_view(
+            perception.id,
+            "perception",
+            perception_dict,
+            context,
+        )
+
+        # Highlight epistemic structure
+        perceived_items = perception_dict.get("perceived_items", {})
+        view["epistemic_statuses"] = {}
+
+        # Count items by epistemic status
+        for item_id, item_data in perceived_items.items():
+            status = item_data.get("epistemic_status", "certain")
+            if status not in view["epistemic_statuses"]:
+                view["epistemic_statuses"][status] = []
+            view["epistemic_statuses"][status].append(item_id)
+
+        # Add interpretation guide
+        view["epistemic_meanings"] = {
+            "certain": "Directly observed, no uncertainty",
+            "believed": "Inferred or remembered, probably true",
+            "hypothesis": "Speculative, may or may not hold",
+            "projected": "Anticipated based on a model but not observed",
+            "error": "Identified as incorrect (diagnosed hallucination)",
+        }
+
+        return view
+
+    def space_view(
+        self,
+        space: Any,
+        context: Optional[LLMViewContext] = None,
+    ) -> dict[str, Any]:
+        """Build an LLM view of a Space object.
+
+        The view includes:
+        - Space metadata (id, type, kind)
+        - Space membership (member objects)
+        - Space relations (connections to other spaces)
+        - Dimensionality and metrics
+
+        Args:
+            space: The Space object.
+            context: LLMViewContext controlling output.
+
+        Returns:
+            A dictionary suitable for LLM consumption.
+        """
+        if context is None:
+            context = LLMViewContext()
+
+        context.mark_visited(space.id)
+
+        space_dict = space.to_dict()
+        view = self._build_base_view(
+            space.id,
+            "space",
+            space_dict,
+            context,
+        )
+
+        # Highlight space properties
+        view["properties"] = {
+            "is_abstract": space_dict.get("is_abstract", False),
+            "is_temporal": space_dict.get("is_temporal", False),
+        }
+
+        if context.include_relations:
+            relations = space_dict.get("relations", {})
+            view["structure"] = {
+                "members": relations.get("member", []),
+                "parent_spaces": relations.get("parent_space", []),
+                "child_spaces": relations.get("child_space", []),
+            }
+
+        return view
+
+
+# Convenience functions for common use cases
+
+def actor_to_llm_view(
+    actor: Any,
+    perception: Optional[Any] = None,
+    include_provenance: bool = False,
+) -> dict[str, Any]:
+    """Export an actor to an LLM view, optionally with perception.
+
+    Args:
+        actor: The Actor object to export.
+        perception: Optional Perception of this actor.
+        include_provenance: Whether to include provenance metadata.
+
+    Returns:
+        An LLM-friendly dictionary representation.
+    """
+    builder = LLMViewBuilder()
+    context = LLMViewContext(include_provenance=include_provenance)
+    return builder.actor_view(actor, context=context, include_perception=perception)
+
+
+def world_to_llm_view(
+    world: Any,
+    include_provenance: bool = False,
+) -> dict[str, Any]:
+    """Export a world to an LLM view.
+
+    Args:
+        world: The World object to export.
+        include_provenance: Whether to include provenance metadata.
+
+    Returns:
+        An LLM-friendly dictionary representation.
+    """
+    builder = LLMViewBuilder()
+    context = LLMViewContext(include_provenance=include_provenance)
+    return builder.world_view(world, context=context)
+
+
+def perception_to_llm_view(
+    perception: Any,
+    include_provenance: bool = False,
+) -> dict[str, Any]:
+    """Export a perception to an LLM view.
+
+    Args:
+        perception: The Perception object to export.
+        include_provenance: Whether to include provenance metadata.
+
+    Returns:
+        An LLM-friendly dictionary representation.
+    """
+    builder = LLMViewBuilder()
+    context = LLMViewContext(include_provenance=include_provenance)
+    return builder.perception_view(perception, context=context)

--- a/src/ometeotl_core/model/base.py
+++ b/src/ometeotl_core/model/base.py
@@ -535,6 +535,47 @@ class ModelObject:
             "provenance": _canonical_json_map(self.provenance),
         }
 
+    def to_llm_view(self) -> JsonMap:
+        """Return a language-model-oriented view of this object.
+
+        The implementation is intentionally centralized here so subclasses can
+        inherit a consistent export surface while the specialized formatting
+        remains in the dedicated IO layer.
+        """
+        from ometeotl_core.io.llm_export import LLMViewBuilder, LLMViewContext
+
+        builder = LLMViewBuilder()
+        context = LLMViewContext()
+
+        object_type = str(self.object_type).lower()
+        if object_type == "world":
+            return builder.world_view(self, context=context)
+        if object_type == "actor":
+            return builder.actor_view(self, context=context)
+        if object_type == "space":
+            return builder.space_view(self, context=context)
+        if object_type == "strategy":
+            return builder.strategy_view(self, context=context)
+        if object_type == "goal":
+            return builder.goal_view(self, context=context)
+        if object_type == "perception":
+            return builder.perception_view(self, context=context)
+
+        view = {
+            "id": self.id,
+            "type": object_type,
+        }
+        if self.attributes:
+            view["attributes"] = _canonical_json_map(self.attributes)
+        if self.state:
+            view["state"] = _canonical_json_map(self.state)
+        if self.relations:
+            view["relations"] = {
+                key: sorted(str(value) for value in values)
+                for key, values in sorted(self.relations.items())
+            }
+        return view
+
     def _base_kwargs(self) -> "JsonMap":
         """Return the base keyword arguments shared by all ModelObject subclasses.
 

--- a/src/ometeotl_core/model/base.py
+++ b/src/ometeotl_core/model/base.py
@@ -574,6 +574,24 @@ class ModelObject:
                 key: sorted(str(value) for value in values)
                 for key, values in sorted(self.relations.items())
             }
+        view["reality"] = {
+            "attributes": view.get("attributes", {}),
+            "state": view.get("state", {}),
+            "relations": view.get("relations", {}),
+        }
+        view["perception"] = None
+        view["epistemic"] = {
+            "status": "certain",
+            "meaning": "Ontological model object",
+            "distinctions": [
+                "reality",
+                "perception",
+                "belief",
+                "hypothesis",
+                "projection",
+            ],
+            "has_perception": False,
+        }
         return view
 
     def _base_kwargs(self) -> "JsonMap":

--- a/src/ometeotl_core/model/perception.py
+++ b/src/ometeotl_core/model/perception.py
@@ -363,3 +363,10 @@ class Perception:
             context=_dict_from_data(data, "context"),
             provenance=_dict_from_data(data, "provenance"),
         )
+
+    def to_llm_view(self) -> JsonMap:
+        """Return an LLM-oriented view of this perception."""
+        from ometeotl_core.io.llm_export import LLMViewBuilder, LLMViewContext
+
+        builder = LLMViewBuilder()
+        return builder.perception_view(self, context=LLMViewContext())

--- a/tests/ometeotl_core/io/__init__.py
+++ b/tests/ometeotl_core/io/__init__.py
@@ -1,0 +1,33 @@
+"""Test package compatibility helpers for the world IO test suite.
+
+Pytest can place this package on ``sys.path`` in a way that shadows the
+standard library ``io`` module. That breaks third-party imports that rely on
+``io.StringIO``. We mirror the stdlib module attributes here so the test
+package stays harmless if it is imported as top-level ``io`` during test
+collection.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sysconfig
+from pathlib import Path
+
+
+def _load_stdlib_io() -> object:
+	stdlib_path = Path(sysconfig.get_path("stdlib")) / "io.py"
+	spec = importlib.util.spec_from_file_location("_stdlib_io", stdlib_path)
+	if spec is None or spec.loader is None:
+		raise ImportError(f"Unable to load stdlib io module from {stdlib_path}")
+
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+_stdlib_io = _load_stdlib_io()
+
+for _name in dir(_stdlib_io):
+	if not _name.startswith("_"):
+		globals()[_name] = getattr(_stdlib_io, _name)
+

--- a/tests/ometeotl_core/io/__init__.py
+++ b/tests/ometeotl_core/io/__init__.py
@@ -9,20 +9,28 @@ collection.
 
 from __future__ import annotations
 
-import importlib.util
-import sysconfig
+import importlib
+import sys
 from pathlib import Path
 
 
 def _load_stdlib_io() -> object:
-	stdlib_path = Path(sysconfig.get_path("stdlib")) / "io.py"
-	spec = importlib.util.spec_from_file_location("_stdlib_io", stdlib_path)
-	if spec is None or spec.loader is None:
-		raise ImportError(f"Unable to load stdlib io module from {stdlib_path}")
+	original_path = list(sys.path)
+	original_io = sys.modules.pop("io", None)
 
-	module = importlib.util.module_from_spec(spec)
-	spec.loader.exec_module(module)
-	return module
+	tests_root = Path(__file__).resolve().parents[3]
+
+	try:
+		sys.path = [
+			path
+			for path in original_path
+			if path and tests_root.as_posix() not in Path(path).as_posix()
+		]
+		return importlib.import_module("io")
+	finally:
+		sys.path = original_path
+		if original_io is not None:
+			sys.modules["io"] = original_io
 
 
 _stdlib_io = _load_stdlib_io()

--- a/tests/ometeotl_core/io/test_world_io.py
+++ b/tests/ometeotl_core/io/test_world_io.py
@@ -301,6 +301,23 @@ def test_world_to_llm_view_summarizes_registry_members_without_error():
     }
 
 
+def test_world_to_llm_view_sorts_member_ids_deterministically():
+    """LLM export must sort registry member IDs regardless of registration order."""
+    world = World(id="world-io-sorted-members")
+    world.register_object(Actor(id="actor-z"))
+    world.register_object(Actor(id="actor-a"))
+    world.register_object(Resource(id="resource-z"))
+    world.register_object(Resource(id="resource-a"))
+    world.register_object(Space(id="space-z"))
+    world.register_object(Space(id="space-a"))
+
+    view = world_to_llm_view(world)
+
+    assert view["members"]["actors"] == ["actor-a", "actor-z"]
+    assert view["members"]["resources"] == ["resource-a", "resource-z"]
+    assert view["members"]["spaces"] == ["space-a", "space-z"]
+
+
 def test_model_objects_expose_to_llm_view_directly():
     """Model objects should expose the LLM view through the shared base API."""
     world = _build_world()
@@ -348,6 +365,135 @@ def test_strategy_goal_and_perception_expose_direct_llm_views():
     assert perception_view["epistemic_statuses"]["hypothesis"][0]["kind"] == "relation"
     assert perception_view["epistemic_statuses"]["projected"][0]["kind"] == "component_link"
     assert perception_view["epistemic"]["has_perception"] is True
+
+
+def test_perception_llm_view_is_stable_across_insertion_order():
+    """Perception LLM export must be deterministic across insertion orders."""
+    perception_a = Perception(
+        id="perception-order-a",
+        actor_id="actor-1",
+        source_id="world-1",
+        perceived_spaces={
+            "zone-b": PerceivedSpace(space=Space(id="zone-b"), epistemic_status="certain"),
+            "zone-a": PerceivedSpace(space=Space(id="zone-a"), epistemic_status="certain"),
+        },
+        perceived_memberships=[
+            PerceivedMembership(
+                membership=SpaceObjectMembership(
+                    object_id="actor-2",
+                    space_id="zone-b",
+                    role="occupies",
+                ),
+                epistemic_status="believed",
+            ),
+            PerceivedMembership(
+                membership=SpaceObjectMembership(
+                    object_id="actor-1",
+                    space_id="zone-a",
+                    role="occupies",
+                ),
+                epistemic_status="believed",
+            ),
+        ],
+        perceived_relations=[
+            PerceivedRelation(
+                relation=SpaceRelation(
+                    source_space_id="zone-b",
+                    target_space_id="zone-c",
+                    relation_type="adjacent_to",
+                ),
+                epistemic_status="hypothesis",
+            ),
+            PerceivedRelation(
+                relation=SpaceRelation(
+                    source_space_id="zone-a",
+                    target_space_id="zone-b",
+                    relation_type="adjacent_to",
+                ),
+                epistemic_status="hypothesis",
+            ),
+        ],
+        perceived_component_links=[
+            PerceivedComponentLink(
+                link_id="link-z",
+                composite_id="actor-z",
+                component_id="actor-2",
+                epistemic_status="projected",
+            ),
+            PerceivedComponentLink(
+                link_id="link-a",
+                composite_id="actor-a",
+                component_id="actor-1",
+                epistemic_status="projected",
+            ),
+        ],
+    )
+
+    perception_b = Perception(
+        id="perception-order-a",
+        actor_id="actor-1",
+        source_id="world-1",
+        perceived_spaces={
+            "zone-a": PerceivedSpace(space=Space(id="zone-a"), epistemic_status="certain"),
+            "zone-b": PerceivedSpace(space=Space(id="zone-b"), epistemic_status="certain"),
+        },
+        perceived_memberships=[
+            PerceivedMembership(
+                membership=SpaceObjectMembership(
+                    object_id="actor-1",
+                    space_id="zone-a",
+                    role="occupies",
+                ),
+                epistemic_status="believed",
+            ),
+            PerceivedMembership(
+                membership=SpaceObjectMembership(
+                    object_id="actor-2",
+                    space_id="zone-b",
+                    role="occupies",
+                ),
+                epistemic_status="believed",
+            ),
+        ],
+        perceived_relations=[
+            PerceivedRelation(
+                relation=SpaceRelation(
+                    source_space_id="zone-a",
+                    target_space_id="zone-b",
+                    relation_type="adjacent_to",
+                ),
+                epistemic_status="hypothesis",
+            ),
+            PerceivedRelation(
+                relation=SpaceRelation(
+                    source_space_id="zone-b",
+                    target_space_id="zone-c",
+                    relation_type="adjacent_to",
+                ),
+                epistemic_status="hypothesis",
+            ),
+        ],
+        perceived_component_links=[
+            PerceivedComponentLink(
+                link_id="link-a",
+                composite_id="actor-a",
+                component_id="actor-1",
+                epistemic_status="projected",
+            ),
+            PerceivedComponentLink(
+                link_id="link-z",
+                composite_id="actor-z",
+                component_id="actor-2",
+                epistemic_status="projected",
+            ),
+        ],
+    )
+
+    view_a = perception_a.to_llm_view()
+    view_b = perception_b.to_llm_view()
+
+    assert view_a["perception"] == view_b["perception"]
+    assert view_a["epistemic_statuses"] == view_b["epistemic_statuses"]
 
 
 def test_space_and_resource_expose_direct_llm_views():

--- a/tests/ometeotl_core/io/test_world_io.py
+++ b/tests/ometeotl_core/io/test_world_io.py
@@ -216,3 +216,19 @@ def test_world_to_llm_view_summarizes_registry_members_without_error():
         "spaces": [],
         "resources": ["resource-registered"],
     }
+
+
+def test_model_objects_expose_to_llm_view_directly():
+    """Model objects should expose the LLM view through the shared base API."""
+    world = _build_world()
+    actor = world.model_registry.get("actor-registered")
+
+    assert actor is not None
+
+    world_view = world.to_llm_view()
+    actor_view = actor.to_llm_view()
+
+    assert world_view["type"] == "world"
+    assert world_view["members_summary"]["total_actors"] == 1
+    assert actor_view["type"] == "actor"
+    assert actor_view["kind"] == "generic"

--- a/tests/ometeotl_core/io/test_world_io.py
+++ b/tests/ometeotl_core/io/test_world_io.py
@@ -13,10 +13,21 @@ from ometeotl_core.io import (
     world_to_json,
     world_to_yaml,
 )
+from ometeotl_core.model.actions import Action
 from ometeotl_core.model.actors import Actor
+from ometeotl_core.model.base import ModelObject
+from ometeotl_core.model.goals import Goal
+from ometeotl_core.model.perception import (
+    Perception,
+    PerceivedComponentLink,
+    PerceivedMembership,
+    PerceivedRelation,
+    PerceivedSpace,
+)
 from ometeotl_core.model.resources import Resource
 from ometeotl_core.model.space_relations import SpaceRelation
-from ometeotl_core.model.spaces import Space
+from ometeotl_core.model.spaces import Space, SpaceObjectMembership
+from ometeotl_core.model.strategies import Strategy, StrategyNode
 from ometeotl_core.model.world import World
 from ometeotl_core.validation import (
     StructuralValidator,
@@ -47,6 +58,78 @@ def _build_world() -> World:
     world.register_object(actor)
     world.register_object(resource)
     return world
+
+
+def _build_strategy() -> Strategy:
+    strategy = Strategy(
+        id="strategy-io-1",
+        actor_id="actor-1",
+        goal_id="goal-1",
+        root_node_id="node-1",
+        nodes=[
+            StrategyNode(
+                node_id="node-1",
+                action_id="action-1",
+            )
+        ],
+    )
+    strategy.add_relation("action", "action-1")
+    return strategy
+
+
+def _build_goal() -> Goal:
+    goal = Goal(
+        id="goal-io-1",
+        actor_id="actor-1",
+        kind="final",
+        priority=0.5,
+        status="active",
+        target_condition={"kind": "sample"},
+    )
+    goal.add_relation("actor", "actor-1")
+    goal.add_relation("target_space", "zone-a")
+    return goal
+
+
+def _build_perception() -> Perception:
+    return Perception(
+        id="perception-io-1",
+        actor_id="actor-1",
+        source_id="world-io-1",
+        perceived_spaces={
+            "zone-a": PerceivedSpace(
+                space=Space(id="zone-a"),
+                epistemic_status="certain",
+            )
+        },
+        perceived_memberships=[
+            PerceivedMembership(
+                membership=SpaceObjectMembership(
+                    object_id="actor-1",
+                    space_id="zone-a",
+                ),
+                epistemic_status="believed",
+            )
+        ],
+        perceived_relations=[
+            PerceivedRelation(
+                relation=SpaceRelation(
+                    source_space_id="zone-a",
+                    target_space_id="zone-b",
+                    relation_type="adjacent_to",
+                ),
+                epistemic_status="hypothesis",
+            )
+        ],
+        perceived_component_links=[
+            PerceivedComponentLink(
+                link_id="link-1",
+                composite_id="actor-1",
+                component_id="actor-2",
+                epistemic_status="projected",
+            )
+        ],
+    )
 
 
 def test_world_to_json_is_deterministic():
@@ -232,3 +315,85 @@ def test_model_objects_expose_to_llm_view_directly():
     assert world_view["members_summary"]["total_actors"] == 1
     assert actor_view["type"] == "actor"
     assert actor_view["kind"] == "generic"
+
+
+def test_strategy_goal_and_perception_expose_direct_llm_views():
+    """Strategy, goal, and perception objects should expose direct LLM views."""
+    strategy = _build_strategy()
+    goal = _build_goal()
+    perception = _build_perception()
+
+    strategy_view = strategy.to_llm_view()
+    goal_view = goal.to_llm_view()
+    perception_view = perception.to_llm_view()
+
+    assert strategy_view["type"] == "strategy"
+    assert strategy_view["structure"]["action"] == ["action-1"]
+    assert strategy_view["reality"]["relations"]["action"] == ["action-1"]
+    assert strategy_view["perception"] is None
+    assert strategy_view["epistemic"]["has_perception"] is False
+
+    assert goal_view["type"] == "goal"
+    assert goal_view["structure"]["actor"] == ["actor-1"]
+    assert goal_view["structure"]["target_space"] == ["zone-a"]
+    assert goal_view["reality"]["relations"]["actor"] == ["actor-1"]
+    assert goal_view["perception"] is None
+    assert goal_view["epistemic"]["status"] == "certain"
+
+    assert perception_view["type"] == "perception"
+    assert perception_view["reality"]["actor_id"] == "actor-1"
+    assert perception_view["perception"]["perceived_spaces"]["zone-a"]["epistemic_status"] == "certain"
+    assert perception_view["epistemic_statuses"]["certain"][0]["kind"] == "space"
+    assert perception_view["epistemic_statuses"]["believed"][0]["kind"] == "membership"
+    assert perception_view["epistemic_statuses"]["hypothesis"][0]["kind"] == "relation"
+    assert perception_view["epistemic_statuses"]["projected"][0]["kind"] == "component_link"
+    assert perception_view["epistemic"]["has_perception"] is True
+
+
+def test_space_and_resource_expose_direct_llm_views():
+    """Space and resource objects should also use the shared direct LLM view API."""
+    space = Space(id="space-llm-1")
+    resource = Resource(id="resource-llm-1")
+    resource.kind = "material"
+
+    space_view = space.to_llm_view()
+    resource_view = resource.to_llm_view()
+
+    assert space_view["type"] == "space"
+    assert space_view["reality"]["attributes"]["kind"] == "abstract"
+    assert space_view["perception"] is None
+    assert space_view["epistemic"]["status"] == "certain"
+
+    assert resource_view["type"] == "resource"
+    assert resource_view["reality"]["attributes"]["kind"] == "material"
+    assert resource_view["perception"] is None
+    assert resource_view["epistemic"]["has_perception"] is False
+
+
+def test_action_and_generic_model_object_expose_direct_llm_views():
+    """Action and plain model objects should use the generic LLM fallback."""
+    action = Action(
+        id="action-llm-1",
+        actor_id="actor-1",
+        world_id="world-1",
+        space_id="space-1",
+    )
+    generic = ModelObject(
+        id="generic-llm-1",
+        object_type="custom-object",
+    )
+    generic.set_attribute("label", "Generic Object")
+
+    action_view = action.to_llm_view()
+    generic_view = generic.to_llm_view()
+
+    assert action_view["type"] == "action"
+    assert action_view["reality"]["attributes"] == {}
+    assert action_view["reality"]["relations"] == {}
+    assert action_view["perception"] is None
+    assert action_view["epistemic"]["has_perception"] is False
+
+    assert generic_view["type"] == "custom-object"
+    assert generic_view["reality"]["attributes"]["label"] == "Generic Object"
+    assert generic_view["perception"] is None
+    assert generic_view["epistemic"]["status"] == "certain"

--- a/tests/ometeotl_core/io/test_world_io.py
+++ b/tests/ometeotl_core/io/test_world_io.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 from ometeotl_core.io import (
+    world_to_llm_view,
     world_from_json,
     world_from_mapping,
     world_from_yaml,
@@ -195,3 +196,23 @@ def test_world_json_and_yaml_exports_describe_same_payload():
     yaml_payload = yaml.safe_load(world_to_yaml(world))
 
     assert json_payload == yaml_payload == world.to_dict()
+
+
+def test_world_to_llm_view_summarizes_registry_members_without_error():
+    """LLM export should summarize registered objects using the real registry API."""
+    world = _build_world()
+
+    view = world_to_llm_view(world)
+
+    assert view["id"] == "world-io-1"
+    assert view["type"] == "world"
+    assert view["members_summary"] == {
+        "total_actors": 1,
+        "total_spaces": 0,
+        "total_resources": 1,
+    }
+    assert view["members"] == {
+        "actors": ["actor-registered"],
+        "spaces": [],
+        "resources": ["resource-registered"],
+    }


### PR DESCRIPTION
## Why
This PR delivers a dedicated LLM export path for core objects so the system can expose explicit reality, perception, and epistemic views in a deterministic structure.  
It closes the gap between canonical model serialization and AI-facing exports, while keeping responsibilities separated between model and IO layers.

## Link to SPEC
- specs_EN.md: F-5 LLM/SLM view must distinguish reality, perception, belief, hypothesis, projection.
- specs_EN.md: F-1 canonical serialization.
- specs_EN.md: F-6 determinism for diffable exports.
- specs_EN.md: F-14 explicit epistemic status.
- specs_EN.md: F-24 separation of responsibilities.
- specs_EN.md: F-26 minimum interfaces including LLMExportable.
- specs_EN.md: P-5 reality/perception dissociation.

## Architectural impact
- Modified layers: core IO layer, model bridge points, and tests.
- Consistency with spec:
  - Export logic is centralized in IO.
  - Model layer exposes a lightweight dispatch bridge to IO exporter.
  - No business-rule migration into infrastructure layers.
  - Tests validate behavior from user-facing entry points.

## What changed
- Added a dedicated LLM export module with structured builders for world, actor, strategy, goal, perception, and related objects.
- Added a generic model-level dispatcher to call LLM export by object type with a safe fallback structure.
- Added direct perception bridge support for LLM view generation.
- Refactored export internals to reduce duplication via shared helper blocks for reality/perception/epistemic payload wiring.
- Extended regression coverage for direct to_llm_view calls across object families.
- Added test package compatibility shim to avoid stdlib IO shadowing during test collection.

## Risks
- Backward compatibility:
  - Low risk, because this is additive (new exporter path + bridge), not a schema-breaking rewrite of existing canonical to_dict behavior.
- Edge cases:
  - Potential risk on unknown object types; mitigated by fallback shape and regression checks.
  - Potential risk in registry-driven world summaries; covered by tests.
- Performance:
  - Low to moderate overhead for large object graphs due to payload assembly; no algorithmic regressions identified in current scope.
- Concurrency:
  - No new shared mutable global state introduced.

## What to review carefully
- Correctness of epistemic grouping and status labeling in exported payloads.
- Deterministic ordering and stability of generated structures for diffability.
- Fallback behavior for generic objects and unsupported object types.
- Test shim behavior around IO import resolution during pytest collection.

## Tests
- Added/updated IO export and direct-call regression tests in the new test set.
- Verified targeted suite:
  - 0 failed on world IO test module.
- Coverage focus:
  - World, actor, strategy, goal, perception, space, resource, action, and generic fallback export paths.
