### PR TITLE
Feature/generation layer

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -135,3 +135,22 @@ When analyzing or modifying code, proactively scan for the following classes of 
 ## Project-specific rules 
 - Domain behavior lives in the `model` module
 - `Core` is only for generic infrastructure and computation, type-handling etc.
+
+## Audit artifacts
+
+When a test exercises serialization, export, export/import roundtrip, LLM view generation, or generation output intended for inspection, it must produce auditable artifacts under `local_lab/artifacts/`.
+
+Rules:
+- Never write audit artifacts inside tracked source folders such as `src/`, `tests/`, or `doc-site/`.
+- Use `local_lab/artifacts/` as the only default root for test-generated audit files.
+- Organize artifacts in relevant thematic subfolders that reflect the layer or export surface, for example:
+  - `local_lab/artifacts/exports/model/to_dict/`
+  - `local_lab/artifacts/exports/model/to_llm_view/`
+  - `local_lab/artifacts/exports/io/world_to_json/`
+  - `local_lab/artifacts/exports/io/world_to_yaml/`
+  - `local_lab/artifacts/generation/`
+- Artifact filenames must be deterministic, stable, and overwritten on each run. Do not create timestamped, random, or accumulating filenames by default.
+- Audit artifact generation must remain observational only: it must never modify domain behavior, move business logic out of the intended layer, or become a prerequisite for production code execution.
+- Prefer the shared test helpers and centralized pytest audit capture already present in the repository. Extend the shared mechanism rather than duplicating ad hoc file-writing logic in individual tests.
+- When a new export surface is introduced, update the shared audit capture so that the new surface is recorded consistently across the repository.
+- Any new behavior that changes exported structures should include or update tests that prove both correctness and the corresponding audit artifact output.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The name **Ometeotl** draws from Aztec mythology, where *Ōme* means "two" or "d
 
 ## Work in Progress
 
-This project is **actively under development**. The current codebase already implements a functional core centered on modeling, perception, projection, strategy, teleology, game-layer utility ranking, composite actors, server-authoritative runtime boundaries, and a dedicated validation layer. Generation, IO packaging, and higher-level examples remain incomplete.
+This project is **actively under development**. The current codebase implements a functional core covering modeling, perception, projection, strategy, teleology, game-layer utility ranking, composite actors, server-authoritative runtime boundaries, a dedicated validation layer, canonical IO (JSON/YAML), LLM-oriented export, and a complete contextual generation pipeline with pluggable rule engine and optional LLM-assisted refinement.
 
 ## Current Implementation Status
 
@@ -37,7 +37,7 @@ This project is **actively under development**. The current codebase already imp
     - ...
   - to add, lastly, an adapter layer `ometeotl_adapters`, which implements each specialization layer with a reputable library.
 
-As of April 2026, the repository includes:
+As of May 2026, the repository includes:
 
 - A full model core in `src/ometeotl_core/model/` with `ModelObject`, `GenericObject`, `Actor`, `Resource`, `Space`, `World`, and registry support.
 - Spatial topology with `SpaceObjectGraph`, `SpaceObjectMembership`, `SpaceRelation`, and `SpaceRelationGraph`.
@@ -50,7 +50,16 @@ As of April 2026, the repository includes:
 - A sensor pipeline with coverage rules, noise rules, deterministic timestamp-aware perception ids, and epistemic status validation.
 - A server-authoritative core runtime with `AuthorityCommandHandler`, command envelopes/results, audit entries, and runtime bootstrap helpers.
 - A dedicated validation layer with syntactic, structural, temporal, spatial, admissibility, epistemic, and completeness validators, plus policy-based hardening profiles (`observe_only`, `enforce_structure`, `enforce_domain`) and diagnostics.
-- A test suite currently collecting `317` tests across `tests/ometeotl_core/model/`, `tests/ometeotl_core/generic/`, `tests/ometeotl_core/game/`, `tests/ometeotl_core/io/`, and `tests/ometeotl_core/validation/`.
+- A canonical IO layer in `src/ometeotl_core/io/` with JSON/YAML world export and import, and a dedicated LLM/SLM view exporter (`to_llm_view()`) that explicitly separates reality, perception, belief, hypothesis, and projection.
+- A contextual generation pipeline in `src/ometeotl_core/generation/` with:
+  - `GenerationContext` declarative input dataclass with nested child contexts, placement instructions, and constraint declarations.
+  - Class-based `ContextualBuilder` abstraction for all core kinds (world, actor, strategy, goal, perception).
+  - Pluggable `GenerationRule` / `GenerationRuleSet` / `RuleRegistry` rule engine with built-in constraint propagation (temporal, spatial, admissibility).
+  - `LLMGenerationAdapter` for optional provider-agnostic LLM-assisted context refinement.
+  - `ContextualGenerationPipeline` orchestrating rules → build → optional registration → optional validation → `GenerationResult`.
+  - `from_context()` classmethods on `World`, `Actor`, `Strategy`, and `Goal`.
+  - Four runnable demo scenarios in `generation/examples.py`.
+- A test suite currently collecting `396` tests across `tests/ometeotl_core/model/`, `tests/ometeotl_core/generic/`, `tests/ometeotl_core/game/`, `tests/ometeotl_core/io/`, `tests/ometeotl_core/validation/`, and `tests/ometeotl_core/generation/`.
 
 ## Current Architecture
 
@@ -67,12 +76,10 @@ The implemented architecture follows the separation defined in `specs_EN.md`:
 
 ## Near-Term TODOs
 
-- Implement the `io/` layer for explicit import/export workflows beyond object-local serialization helpers.
-- Implement the `generation/` layer and `from_context`-style construction pipeline.
+- Add a full generation roundtrip integration test covering the complete chain (context → pipeline → generated objects → IO export → `to_llm_view()` → parse → validate) and a concrete 2-actor game scenario wiring goals, strategies, and utility ranking end to end.
 - Extend the `game/` layer beyond current utility/ranking primitives with richer solver-facing abstractions.
 - Extend the strategy layer to support one action producing several alternative projected outcomes, with branch-specific successor perceived states carried by `StrategyOutcomeBranch` rather than duplicated on `StrategyNode`.
 - Add reference examples and end-to-end demo worlds in `examples/`.
-- Continue aligning public docs with the now-implemented projection, strategy, teleology, utility, authority, and composite-actor capabilities.
 
 ## Join the Journey
 

--- a/doc-site/content/en/documentation/class-reference/_index.md
+++ b/doc-site/content/en/documentation/class-reference/_index.md
@@ -119,3 +119,13 @@ Repository source:
 - [IO index](/ometeotl/documentation/class-reference/io/)
 - [World export](/ometeotl/documentation/class-reference/io/world-export/)
 - [World import / WorldImportResult](/ometeotl/documentation/class-reference/io/world-import/)
+- [LLM view export](/ometeotl/documentation/class-reference/io/llm-view-export/)
+
+### Generation
+- [Generation index](/ometeotl/documentation/class-reference/generation/)
+- [GenerationContext / GenerationPlacement](/ometeotl/documentation/class-reference/generation/generation-context/)
+- [ContextualBuilder / per-kind builders](/ometeotl/documentation/class-reference/generation/context-builder/)
+- [GenerationRule / GenerationRuleSet / RuleRegistry](/ometeotl/documentation/class-reference/generation/rule-engine/)
+- [LLMGenerationAdapter / LLMRefinementResult](/ometeotl/documentation/class-reference/generation/llm-integration/)
+- [ContextualGenerationPipeline / GenerationResult](/ometeotl/documentation/class-reference/generation/pipeline/)
+- [Generation examples](/ometeotl/documentation/class-reference/generation/examples/)

--- a/doc-site/content/en/documentation/class-reference/generation/_index.md
+++ b/doc-site/content/en/documentation/class-reference/generation/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Generation"
+description: "Contextual generation pipeline: context builders, rule engine, LLM integration, and pipeline orchestration"
+---
+
+Generation reference pages:
+
+- [GenerationContext](/ometeotl/documentation/class-reference/generation/generation-context/)
+- [GenerationPlacement](/ometeotl/documentation/class-reference/generation/generation-context/)
+- [ContextualBuilder / per-kind builders](/ometeotl/documentation/class-reference/generation/context-builder/)
+- [GenerationRule / GenerationRuleSet](/ometeotl/documentation/class-reference/generation/rule-engine/)
+- [RuleRegistry](/ometeotl/documentation/class-reference/generation/rule-engine/)
+- [LLMGenerationAdapter](/ometeotl/documentation/class-reference/generation/llm-integration/)
+- [ContextualGenerationPipeline / GenerationResult](/ometeotl/documentation/class-reference/generation/pipeline/)
+- [Generation examples](/ometeotl/documentation/class-reference/generation/examples/)

--- a/doc-site/content/en/documentation/class-reference/generation/context-builder.md
+++ b/doc-site/content/en/documentation/class-reference/generation/context-builder.md
@@ -1,0 +1,57 @@
+---
+title: "ContextualBuilder / per-kind builders"
+---
+
+Source:
+- [src/ometeotl_core/generation/context_builder.py](https://github.com/kakchouch/ometeotl/blob/main/src/ometeotl_core/generation/context_builder.py)
+
+__
+
+Local role:
+Typed class-based abstraction wrapping the function-based builders in `builders.py`. Provides a stable override point for kind-specific generation behavior.
+
+Big-picture role:
+Enables callers to compose or replace per-kind generation logic without touching the pipeline. Satisfies the pluggable builder requirement of the generation architecture (F-16).
+
+Inheritance (`ContextualBuilder`):
+- `ABC`, `Generic[TGenerated]`
+
+Parameters and fields:
+- `kind: str` — class-level attribute; must be declared on each concrete subclass
+
+Methods (`ContextualBuilder`):
+- `ensure_kind(context)` — raises `ValueError` if `context.kind` does not match `self.kind`
+- `build(context) -> TGenerated` — abstract; must be implemented by subclasses
+
+Concrete builders:
+- `WorldContextualBuilder` — `kind = "world"`, delegates to `build_world(context)`
+- `ActorContextualBuilder` — `kind = "actor"`, delegates to `build_actor(context)`
+- `StrategyContextualBuilder` — `kind = "strategy"`, delegates to `build_strategy(context)`
+- `GoalContextualBuilder` — `kind = "goal"`, delegates to `build_goal(context)`
+- `PerceptionContextualBuilder` — `kind = "perception"`, delegates to `build_perception(context)`
+
+Module-level helpers:
+- `default_contextual_builders()` — returns a `dict[str, ContextualBuilder]` mapping all five built-in kind strings to their instances
+- `build_with_context_builder(context, *, builders=None)` — looks up `context.kind` in the builders dict and calls `build(context)`; raises `ValueError` on unknown kind
+
+Notes:
+- Every concrete `build()` implementation must call `ensure_kind` first to prevent silent wrong-kind generation.
+- `default_contextual_builders()` returns a fresh dict each call — safe to mutate.
+
+See also:
+- [GenerationContext](/ometeotl/documentation/class-reference/generation/generation-context/)
+- [Pipeline](/ometeotl/documentation/class-reference/generation/pipeline/)
+
+## Customization pattern
+
+```python
+class MyActorBuilder(ActorContextualBuilder):
+    def build(self, context):
+        self.ensure_kind(context)
+        ctx = context.copy_with(attributes={**context.attributes, "source": "custom"})
+        return build_actor(ctx)
+
+builders = default_contextual_builders()
+builders["actor"] = MyActorBuilder()
+result = build_with_context_builder(context, builders=builders)
+```

--- a/doc-site/content/en/documentation/class-reference/generation/examples.md
+++ b/doc-site/content/en/documentation/class-reference/generation/examples.md
@@ -1,0 +1,31 @@
+---
+title: "Generation examples"
+---
+
+Source:
+- [src/ometeotl_core/generation/examples.py](https://github.com/kakchouch/ometeotl/blob/main/src/ometeotl_core/generation/examples.py)
+
+__
+
+Local role:
+Self-contained runnable demo scenarios for the contextual generation pipeline. Each function is independent and illustrates one generation pattern end to end.
+
+Big-picture role:
+Executable documentation for the generation architecture (F-16 to F-22). Run `python -m ometeotl_core.generation.examples` to see all four scenarios.
+
+Module-level helpers:
+- `demo_simple_world()` — generates a world with 2 spaces and 1 placed actor; demonstrates nested contexts and `GenerationPlacement`
+- `demo_multi_actor_world()` — generates a world with 3 actors and temporal/spatial constraint propagation; demonstrates deduplication and `combined_generation_rules`
+- `demo_perception_generation()` — generates a `Perception` object for an actor observing a known space; demonstrates metadata-driven perception and registry-selected rule sets
+- `demo_goal_generation()` — generates a `Goal` with admissibility constraints; demonstrates confidence clamping, capability propagation, and priority validation
+- `run_all()` — runs all four scenarios in sequence; called when the module is executed directly
+
+Notes:
+- All scenarios use `ContextualGenerationPipeline` with no custom configuration unless stated.
+- `demo_perception_generation` selects the `"default"` rule set from `default_rule_registry()` to demonstrate registry-driven rule selection.
+- `Goal.priority` must be in `[0.0, 1.0]` — see [Goal](/ometeotl/documentation/class-reference/model/goals/goal/).
+
+See also:
+- [GenerationContext](/ometeotl/documentation/class-reference/generation/generation-context/)
+- [Pipeline](/ometeotl/documentation/class-reference/generation/pipeline/)
+- [Rule engine](/ometeotl/documentation/class-reference/generation/rule-engine/)

--- a/doc-site/content/en/documentation/class-reference/generation/generation-context.md
+++ b/doc-site/content/en/documentation/class-reference/generation/generation-context.md
@@ -1,0 +1,59 @@
+---
+title: "GenerationContext / GenerationPlacement"
+---
+
+Source:
+- [src/ometeotl_core/generation/context.py](https://github.com/kakchouch/ometeotl/blob/main/src/ometeotl_core/generation/context.py)
+
+__
+
+Local role:
+Declarative input dataclass threaded through every generation function and builder. Carries identity, attributes, nested child contexts, placement instructions, and optional constraint overrides.
+
+Big-picture role:
+Central data-transfer object of the generation pipeline (F-16 to F-22). Consumed by [ContextualBuilder](/ometeotl/documentation/class-reference/generation/context-builder/), the [rule engine](/ometeotl/documentation/class-reference/generation/rule-engine/), and [ContextualGenerationPipeline](/ometeotl/documentation/class-reference/generation/pipeline/).
+
+Parameters and fields (`GenerationContext`):
+- `kind: str` — target entity kind: `"world"`, `"actor"`, `"goal"`, `"strategy"`, `"perception"`, `"space"`, `"resource"`, `"action"`
+- `id: str` — stable identity of the generated object
+- `label: str` — promoted into `attributes["label"]` by the `promote_label` rule
+- `attributes: dict` — arbitrary key/value pairs forwarded to the model object
+- `relations: dict[str, list[str]]` — named relation groups; duplicates deduplicated by `normalize_relations`
+- `state: dict`, `context: dict`, `provenance: dict` — forwarded verbatim to the model object
+- `spaces`, `actors`, `resources`, `goals`, `strategies`, `actions: list[GenerationContext]` — nested child contexts for world generation
+- `placements: list[GenerationPlacement]` — explicit object-to-space placement instructions
+- `metadata: dict` — read by constraint propagation rules; also forwarded into `merged_context()`
+- `rules: dict` — rule override hints (reserved)
+- `constraints: dict` — constraint declarations consumed by the [rule engine](/ometeotl/documentation/class-reference/generation/rule-engine/)
+- `operation: str` — `"create"` (default), `"partial_update"`, `"corrective_update"`
+- `registration_policy: str` — `"none"` (default), `"if_available"`, `"require"`
+- `validate: bool` — if `True`, pipeline runs validation after generation
+- `validation_mode: str` — `"lenient"` (default) or `"strict"`
+- `stage_modes: dict[str, str]` — per-stage validation mode overrides
+
+Methods:
+- `merged_attributes()` — attributes with `label` promoted when non-empty
+- `merged_context()` — ambient context enriched with `metadata`, `rules`, `constraints` under a `"generation"` key
+- `normalized_relations()` — relations with each list deduplicated and sorted
+- `copy_with(**overrides)` — shallow copy with field overrides; used by the rule engine on every rule application
+- `child_collections()` — all nested child context lists in one stable mapping
+
+Parameters and fields (`GenerationPlacement`):
+- `object_id: str` — ID of the object to place
+- `space_id: str` — ID of the target space
+- `role: str = "occupies"` — semantic role of the placement
+- `metadata: dict = {}` — optional placement metadata
+
+Methods (`GenerationPlacement`):
+- `to_dict()` — returns a plain dict representation
+
+Notes:
+- `GenerationContext` is mutable; all fields default so callers only set what they need.
+- `GenerationPlacement` is a frozen dataclass.
+- `copy_with` is the only intended mutation path inside the rule engine — direct field mutation should be avoided.
+- `constraints` keys `"temporal"`, `"spatial"`, `"admissibility"` are the conventionally recognized namespaces.
+
+See also:
+- [Rule engine](/ometeotl/documentation/class-reference/generation/rule-engine/)
+- [ContextualBuilder](/ometeotl/documentation/class-reference/generation/context-builder/)
+- [Pipeline](/ometeotl/documentation/class-reference/generation/pipeline/)

--- a/doc-site/content/en/documentation/class-reference/generation/llm-integration.md
+++ b/doc-site/content/en/documentation/class-reference/generation/llm-integration.md
@@ -1,0 +1,52 @@
+---
+title: "LLMGenerationAdapter / LLMRefinementResult"
+---
+
+Source:
+- [src/ometeotl_core/generation/llm_integration.py](https://github.com/kakchouch/ometeotl/blob/main/src/ometeotl_core/generation/llm_integration.py)
+
+__
+
+Local role:
+Provider-agnostic bridge that converts a `GenerationContext` into a prompt, calls an external text generator, parses the response, and returns a refined `GenerationContext`.
+
+Big-picture role:
+Optional pre-refinement step in the hybrid generation workflow (F-20). Keeps LLM usage opt-in and auditable — the pipeline does not call the adapter automatically.
+
+Parameters and fields (`LLMGenerationAdapter`):
+- `text_generator: Callable[[str], str]` — any callable that takes a prompt and returns a text response
+- `response_parser: Callable[[str], Mapping[str, Any]] | None` — optional custom parser; defaults to `json.loads`-based mapping extraction
+
+Methods (`LLMGenerationAdapter`):
+- `render_prompt(context, *, prompt_template=None) -> str` — serializes context to a deterministic JSON payload embedded in the prompt template
+- `refine(context, *, prompt_template=None) -> LLMRefinementResult` — renders prompt, calls the generator, parses, merges via `copy_with`; falls back to original context on failure
+
+Parameters and fields (`LLMRefinementResult`, frozen dataclass):
+- `refined_context: GenerationContext` — context after LLM-suggested refinements, or original on fallback
+- `raw_response: str` — raw text returned by the generator
+- `used_fallback: bool` — `True` if parsing or merging failed
+- `diagnostics: list[str]` — human-readable messages describing what happened
+
+Notes:
+- The adapter is stateless and side-effect-free beyond the external generator call.
+- Fallback behavior ensures the pipeline is never blocked by an LLM error.
+- Callers must chain the adapter explicitly; the pipeline does not invoke it automatically.
+
+See also:
+- [GenerationContext](/ometeotl/documentation/class-reference/generation/generation-context/)
+- [Pipeline](/ometeotl/documentation/class-reference/generation/pipeline/)
+
+## Provider integration pattern
+
+```python
+def my_llm(prompt: str) -> str:
+    return call_openai_or_anthropic(prompt)
+
+adapter = LLMGenerationAdapter(text_generator=my_llm)
+refinement = adapter.refine(context)
+
+if not refinement.used_fallback:
+    context = refinement.refined_context
+
+result = pipeline.generate(context)
+```

--- a/doc-site/content/en/documentation/class-reference/generation/pipeline.md
+++ b/doc-site/content/en/documentation/class-reference/generation/pipeline.md
@@ -1,0 +1,54 @@
+---
+title: "ContextualGenerationPipeline / GenerationResult"
+---
+
+Source:
+- [src/ometeotl_core/generation/pipeline.py](https://github.com/kakchouch/ometeotl/blob/main/src/ometeotl_core/generation/pipeline.py)
+
+__
+
+Local role:
+Orchestrates the full generation workflow: rule application → builder dispatch → optional registration → optional validation → structured result.
+
+Big-picture role:
+Top-level entry point for the generation architecture (F-16 to F-22). Accepts a `GenerationContext`, applies the configured `GenerationRuleSet`, delegates to the appropriate builder, and returns a `GenerationResult` carrying the generated object, applied rule names, validation outcome, and repair suggestions.
+
+Parameters and fields (`ContextualGenerationPipeline`):
+- `rules: GenerationRuleSet` — rule set applied before building; defaults to `combined_generation_rules()`
+- `validation_pipeline: ValidationPipeline | None` — optional validation pipeline; only runs when `context.validate=True`
+
+Methods (`ContextualGenerationPipeline`):
+- `generate(context, *, world=None) -> GenerationResult` — full pipeline: rules → build → register → validate
+- `generate_from_text_response(context, *, raw_response, ...)` — parses an LLM text response into context overrides then delegates to `generate`
+
+Parameters and fields (`GenerationResult`, dataclass):
+- `generated: Any` — the model object produced by the builder
+- `applied_rule_names: list[str]` — names of rules that were part of the active rule set (in order)
+- `validation: ValidationResult | None` — validation outcome; `None` if validation was not requested
+- `diagnostics: list[str]` — ordered human-readable pipeline stage messages
+- `uncertainty_zones: list[str]` — uncertainty zones declared in the context
+- `repair_suggestions: list[str]` — suggested fixes when validation fails
+
+Notes:
+- Supported `context.operation` values: `"create"`, `"partial_update"`, `"corrective_update"`.
+- Supported `context.registration_policy` values: `"none"`, `"if_available"`, `"require"`.
+- `applied_rule_names` reflects the rule set configuration, not which predicates fired.
+- Validation only runs when `context.validate=True` **and** a `validation_pipeline` is provided.
+- The pipeline does not call `LLMGenerationAdapter` automatically; callers must chain it explicitly.
+
+See also:
+- [GenerationContext](/ometeotl/documentation/class-reference/generation/generation-context/)
+- [Rule engine](/ometeotl/documentation/class-reference/generation/rule-engine/)
+- [LLMGenerationAdapter](/ometeotl/documentation/class-reference/generation/llm-integration/)
+- [Generation examples](/ometeotl/documentation/class-reference/generation/examples/)
+
+## Generation flow
+
+```
+GenerationContext
+    → GenerationRuleSet.apply()        # constraint propagation and normalization
+    → build_from_context()             # kind dispatch → builder
+    → registration_policy check        # optional world registry update
+    → ValidationPipeline.validate()    # optional; only when context.validate=True
+    → GenerationResult
+```

--- a/doc-site/content/en/documentation/class-reference/generation/rule-engine.md
+++ b/doc-site/content/en/documentation/class-reference/generation/rule-engine.md
@@ -1,0 +1,91 @@
+---
+title: "GenerationRule / GenerationRuleSet / RuleRegistry"
+---
+
+Source:
+- [src/ometeotl_core/generation/rule_engine.py](https://github.com/kakchouch/ometeotl/blob/main/src/ometeotl_core/generation/rule_engine.py)
+
+__
+
+Local role:
+Pluggable, ordered transformation layer that refines a `GenerationContext` before it is handed to builders. All rules are deterministic: same input → same output, no side effects.
+
+Big-picture role:
+Implements the rule engine and constraint propagation requirements of F-17 and F-18. Consumed by [ContextualGenerationPipeline](/ometeotl/documentation/class-reference/generation/pipeline/). The `RuleRegistry` enables pluggable policy selection without modifying pipeline code.
+
+Parameters and fields (`GenerationRule`, frozen dataclass):
+- `name: str` — unique human-readable identifier
+- `predicate: Callable[[GenerationContext], bool]` — guard; rule runs only when this returns `True`
+- `apply: Callable[[GenerationContext], GenerationContext]` — pure transformation returning a new context
+
+Methods (`GenerationRule`):
+- `run(context)` — calls predicate; if `True` calls `apply` and returns result, otherwise returns context unchanged
+
+Parameters and fields (`GenerationRuleSet`):
+- `rules: list[GenerationRule]` — ordered rule list (property; returns a copy)
+
+Methods (`GenerationRuleSet`):
+- `apply(context)` — threads the context through each rule in order; returns the final context
+
+Methods (`RuleRegistry`):
+- `register(name, rule_set)` — stores a rule set under `name`; raises `ValueError` on empty name
+- `exists(name) -> bool` — returns `True` if the name is registered
+- `get(name) -> GenerationRuleSet | None` — returns the rule set or `None`
+- `require(name) -> GenerationRuleSet` — returns the rule set; raises `KeyError` on missing name
+- `names() -> list[str]` — sorted list of all registered names
+
+Module-level helpers:
+- `default_generation_rules()` — 2 rules: `normalize_relations`, `promote_label`
+- `temporal_constraint_rules()` — 1 rule: propagates `constraints["temporal"]` into `metadata`
+- `spatial_constraint_rules()` — 1 rule: propagates `constraints["spatial"]` into `metadata`
+- `admissibility_constraint_rules()` — 1 rule: propagates `constraints["admissibility"]` into `metadata`
+- `combined_generation_rules()` — all 5 rules in order; default for `ContextualGenerationPipeline`
+- `default_rule_registry()` — pre-populated `RuleRegistry` with entries: `"default"`, `"temporal"`, `"spatial"`, `"admissibility"`, `"combined"`
+
+Notes:
+- All metadata propagation uses `setdefault` — existing metadata values are never overwritten by constraint rules.
+- `rules.py` re-exports all symbols from `rule_engine.py` for backward compatibility.
+
+See also:
+- [GenerationContext](/ometeotl/documentation/class-reference/generation/generation-context/)
+- [Pipeline](/ometeotl/documentation/class-reference/generation/pipeline/)
+
+## Constraint propagation detail
+
+### `temporal_constraint_rules` — fires when `constraints["temporal"]` is present
+
+| Constraint key | Propagation target | Coercion |
+|---|---|---|
+| `window` | `metadata["horizon"]["window"]` | Positive int; fallback: `1` |
+| `start_step` | `metadata["timeline"]["start_step"]` | Non-negative int; fallback: `0` |
+
+### `spatial_constraint_rules` — fires when `constraints["spatial"]` is present
+
+| Constraint key | Propagation target | Processing |
+|---|---|---|
+| `allowed_spaces` | `metadata["allowed_spaces"]` | Sorted, deduplicated list of non-empty strings |
+| `required_space` | `metadata["space_id"]` | String coercion |
+
+### `admissibility_constraint_rules` — fires when `constraints["admissibility"]` is present
+
+| Constraint key | Propagation target | Processing |
+|---|---|---|
+| `required_capability` | `metadata["required_capability"]` | String coercion |
+| `minimum_confidence` | `metadata["minimum_confidence"]` | Float clamped to `[0.0, 1.0]`; invalid → `0.0` |
+
+## Constraint declaration pattern
+
+```python
+ctx = GenerationContext(
+    kind="goal",
+    id="goal-1",
+    constraints={
+        "temporal": {"window": 10, "start_step": 2},
+        "spatial": {"allowed_spaces": ["north", "south"]},
+        "admissibility": {"required_capability": "mobility", "minimum_confidence": 0.8},
+    },
+    metadata={"actor_id": "actor-1"},
+)
+pipeline = ContextualGenerationPipeline()  # uses combined rules by default
+result = pipeline.generate(ctx)
+```

--- a/doc-site/content/en/documentation/class-reference/io/_index.md
+++ b/doc-site/content/en/documentation/class-reference/io/_index.md
@@ -8,3 +8,4 @@ IO reference pages:
 - [World export](/ometeotl/documentation/class-reference/io/world-export/)
 - [World import](/ometeotl/documentation/class-reference/io/world-import/)
 - [WorldImportResult](/ometeotl/documentation/class-reference/io/world-import/)
+- [LLM view export](/ometeotl/documentation/class-reference/io/llm-view-export/)

--- a/doc-site/content/en/documentation/class-reference/io/llm-view-export.md
+++ b/doc-site/content/en/documentation/class-reference/io/llm-view-export.md
@@ -1,0 +1,50 @@
+---
+title: "LLM view export"
+---
+
+Source:
+- [src/ometeotl_core/io/llm_export.py](https://github.com/kakchouch/ometeotl/blob/main/src/ometeotl_core/io/llm_export.py)
+- [src/ometeotl_core/model/base.py](https://github.com/kakchouch/ometeotl/blob/main/src/ometeotl_core/model/base.py)
+
+Local role:
+Provide a language-model-oriented representation that explicitly separates ontological reality from epistemic/perception-aware views.
+
+Big-picture role:
+This export path implements the dedicated LLM/SLM view requirement (F-5) while preserving ownership boundaries:
+- `model` owns canonical state (`to_dict` and domain classes)
+- `io` owns formatting/projection for external consumers
+
+## Public API
+
+### `world_to_llm_view(world, include_provenance=False)`
+Exports a world-focused LLM payload with:
+- base object shape (`id`, `type`, optional sections)
+- `reality` block
+- member summaries and deterministic member lists
+
+### `actor_to_llm_view(actor, perception=None, include_provenance=False)`
+Exports an actor with:
+- ontological actor slice
+- optional attached perception view
+- explicit epistemic envelope
+
+### `perception_to_llm_view(perception, include_provenance=False)`
+Exports a perception object with:
+- perception payload (`perceived_spaces`, memberships, relations, component links)
+- grouped epistemic statuses (`certain`, `believed`, `hypothesis`, `projected`, `error`)
+
+### `ModelObject.to_llm_view()`
+Shared model-level entrypoint dispatching to `LLMViewBuilder` by object type. Unsupported object types use a generic fallback containing `reality`, `perception`, and `epistemic` sections.
+
+## Determinism and epistemic guarantees
+
+- Perception payload collections are sorted with canonical keys.
+- Epistemic status groups are produced deterministically.
+- World member IDs (`actors`, `spaces`, `resources`) are sorted.
+- Output explicitly exposes distinctions: `reality`, `perception`, `belief`, `hypothesis`, `projection`.
+
+## Validation and scope
+
+- This exporter does not run validation.
+- It assumes input objects are already structurally valid.
+- It is a projection layer, not a business-logic layer.

--- a/doc-site/content/en/documentation/overview.md
+++ b/doc-site/content/en/documentation/overview.md
@@ -58,6 +58,14 @@ Teleology and utility/ranking are now implemented as model and game extensions:
 - [UtilityFunction](/ometeotl/documentation/class-reference/model/utility/utility-function/) defines the abstract utility contract.
 - [WeightedSumUtility](/ometeotl/documentation/class-reference/game/utility/weighted-sum-utility/), [LexicographicUtility](/ometeotl/documentation/class-reference/game/utility/lexicographic-utility/), and [StrategyRanker](/ometeotl/documentation/class-reference/game/utility/strategy-ranker/) provide game-layer utility derivation and strategy ranking over projected terminal states.
 
+Model objects can also be generated programmatically from declarative inputs:
+
+- [GenerationContext](/ometeotl/documentation/class-reference/generation/generation-context/) is the declarative input carrying identity, attributes, nested child contexts, placements, and constraints.
+- [ContextualGenerationPipeline](/ometeotl/documentation/class-reference/generation/pipeline/) orchestrates rule application, builder dispatch, optional registration, and optional validation.
+- [GenerationRule / GenerationRuleSet / RuleRegistry](/ometeotl/documentation/class-reference/generation/rule-engine/) provide pluggable constraint propagation (temporal, spatial, admissibility).
+- [LLMGenerationAdapter](/ometeotl/documentation/class-reference/generation/llm-integration/) enables optional LLM-assisted context refinement before building.
+- `to_llm_view()` on any model object exports a language-model-oriented payload with explicit reality/perception separation ([LLM view export](/ometeotl/documentation/class-reference/io/llm-view-export/)).
+
 For server-authoritative setups, mutations can be routed through:
 
 - [AuthorityCommandHandler](/ometeotl/documentation/class-reference/core/authority-command-handler/)
@@ -81,10 +89,12 @@ The implemented pipeline follows this flow:
 10. Validate payloads/objects with the staged validation pipeline in `ometeotl_core.validation` (syntactic, structural, temporal, spatial, admissibility, epistemic, completeness), using policy profiles (`observe_only`, `enforce_structure`, `enforce_domain`) when needed.
 11. Export a world to canonical JSON or YAML via `ometeotl_core.io` ([world_to_json](/ometeotl/documentation/class-reference/io/world-export/), [world_to_yaml](/ometeotl/documentation/class-reference/io/world-export/), [write_world_json](/ometeotl/documentation/class-reference/io/world-export/), [write_world_yaml](/ometeotl/documentation/class-reference/io/world-export/)).
 12. Re-import a world from JSON or YAML with validated reconstruction via [world_from_json / world_from_yaml](/ometeotl/documentation/class-reference/io/world-import/), which runs syntactic then structural validation before calling `World.from_dict`.
-13. Optionally enforce command gating with [AuthorityCommandHandler](/ometeotl/documentation/class-reference/core/authority-command-handler/).
-14. Represent actor objectives with [Goal](/ometeotl/documentation/class-reference/model/goals/goal/) and optionally decompose them with [GoalDecompositionTree](/ometeotl/documentation/class-reference/model/goals/goal-decomposition-tree/).
-15. Link [Strategy](/ometeotl/documentation/class-reference/model/strategies/strategy/) to a goal and evaluate admissibility with [GoalAdmissibilityChecker](/ometeotl/documentation/class-reference/model/goal-tools/goal-admissibility-checker/).
-16. Evaluate strategy outcomes with a [UtilityFunction](/ometeotl/documentation/class-reference/model/utility/utility-function/) implementation and rank with [StrategyRanker](/ometeotl/documentation/class-reference/game/utility/strategy-ranker/).
+13. Export any entity as a language-model-oriented payload via `to_llm_view()` ([LLM view export](/ometeotl/documentation/class-reference/io/llm-view-export/)), which separates ontological reality from epistemic/perception-aware views.
+14. Optionally enforce command gating with [AuthorityCommandHandler](/ometeotl/documentation/class-reference/core/authority-command-handler/).
+15. Represent actor objectives with [Goal](/ometeotl/documentation/class-reference/model/goals/goal/) and optionally decompose them with [GoalDecompositionTree](/ometeotl/documentation/class-reference/model/goals/goal-decomposition-tree/).
+16. Link [Strategy](/ometeotl/documentation/class-reference/model/strategies/strategy/) to a goal and evaluate admissibility with [GoalAdmissibilityChecker](/ometeotl/documentation/class-reference/model/goal-tools/goal-admissibility-checker/).
+17. Evaluate strategy outcomes with a [UtilityFunction](/ometeotl/documentation/class-reference/model/utility/utility-function/) implementation and rank with [StrategyRanker](/ometeotl/documentation/class-reference/game/utility/strategy-ranker/).
+18. Generate model objects programmatically from declarative [GenerationContext](/ometeotl/documentation/class-reference/generation/generation-context/) inputs using [ContextualGenerationPipeline](/ometeotl/documentation/class-reference/generation/pipeline/), with optional constraint propagation via the [rule engine](/ometeotl/documentation/class-reference/generation/rule-engine/) and optional LLM-assisted context refinement via [LLMGenerationAdapter](/ometeotl/documentation/class-reference/generation/llm-integration/).
 
 Operationally, [World](/ometeotl/documentation/class-reference/model/world/world/) composes three independent graphs/registries:
 
@@ -103,6 +113,7 @@ The test suite follows the same layer separation as the source tree:
 - `tests/ometeotl_core/validation/`: tests for `ometeotl_core.validation.*`
 - `tests/ometeotl_core/game/`: tests for `ometeotl_core.game.*`
 - `tests/ometeotl_core/io/`: tests for `ometeotl_core.io.*`
+- `tests/ometeotl_core/generation/`: tests for `ometeotl_core.generation.*`
 
 Within each layer folder, tests are split by module using one file per module (`test_<module>.py`).
 
@@ -147,6 +158,34 @@ When authority mode is enabled in [World](/ometeotl/documentation/class-referenc
 - immutable audit traces with [AuditEntry](/ometeotl/documentation/class-reference/core/audit-entry/)
 - staged validation with configurable hardening profiles (`observe_only`, `enforce_structure`, `enforce_domain`)
 - structured validation summaries attached to command results and audit entries
+
+### 4. LLM export boundary
+
+`to_llm_view()` is defined on [ModelObject](/ometeotl/documentation/class-reference/model/base/model-object/) and dispatches to [LLMViewBuilder](/ometeotl/documentation/class-reference/io/llm-view-export/) by object type.
+
+The export path (F-5) keeps ownership clean:
+- `model` owns canonical state (`to_dict` and domain classes)
+- `io` owns formatting and projection for external consumers
+
+Output always exposes explicit epistemic distinctions: `reality`, `perception`, `belief`, `hypothesis`, `projection`. Collections and epistemic groups are produced deterministically (sorted keys).
+
+### 5. Generation boundary
+
+The generation layer (F-16 to F-22) converts declarative [GenerationContext](/ometeotl/documentation/class-reference/generation/generation-context/) inputs into model objects through a deterministic pipeline:
+
+```
+GenerationContext
+    → GenerationRuleSet.apply()   # constraint propagation, normalization
+    → build_from_context()        # kind dispatch to builder functions
+    → registration / validation   # optional; driven by context flags
+    → GenerationResult
+```
+
+Key design properties:
+- Rule application is purely functional: each rule receives a context and returns a new one via `copy_with`.
+- [RuleRegistry](/ometeotl/documentation/class-reference/generation/rule-engine/) enables pluggable policy selection at call-site without modifying the pipeline.
+- [LLMGenerationAdapter](/ometeotl/documentation/class-reference/generation/llm-integration/) is explicitly chained by callers — the pipeline never calls it automatically.
+- Constraint propagation rules use `setdefault` semantics, making the pipeline non-destructive: existing metadata survives rule application.
 
 ### 4. Extensibility seam
 

--- a/doc-site/content/en/goals_and_specs/_index.md
+++ b/doc-site/content/en/goals_and_specs/_index.md
@@ -155,22 +155,31 @@ The repository now contains a broader functional V1-incremental core spanning mo
 	- Validator families: syntactic, structural, temporal, spatial, admissibility, epistemic, completeness.
 	- Policy profiles: `observe_only`, `enforce_structure`, `enforce_domain`.
 	- Diagnostics and repair suggestions.
-10. Quality gate:
-	- Automated tests in `tests/ometeotl_core/model/`, `tests/ometeotl_core/generic/`, `tests/ometeotl_core/game/`, `tests/ometeotl_core/io/`, and `tests/ometeotl_core/validation/`.
-	- Current baseline: `317` collected tests.
+10. IO layer in `src/ometeotl_core/io/`:
+	- Canonical JSON and YAML world export (`world_to_json`, `world_to_yaml`, `write_world_json`, `write_world_yaml`).
+	- Validated world import (`world_from_json`, `world_from_yaml`, `WorldImportResult`).
+	- LLM/SLM view exporter (`llm_export.py`): `world_to_llm_view`, `actor_to_llm_view`, `perception_to_llm_view`, and `ModelObject.to_llm_view()` with explicit reality/perception/belief/hypothesis/projection separation.
+11. Generation layer in `src/ometeotl_core/generation/`:
+	- `GenerationContext` declarative input dataclass with nested child contexts, placement instructions, constraint declarations, and `copy_with` for rule-safe mutation.
+	- `ContextualBuilder` ABC with concrete builders for all core kinds (world, actor, strategy, goal, perception).
+	- Pluggable `GenerationRule` / `GenerationRuleSet` / `RuleRegistry` rule engine with built-in constraint propagation (temporal, spatial, admissibility).
+	- `LLMGenerationAdapter` for optional provider-agnostic LLM-assisted context refinement with fallback.
+	- `ContextualGenerationPipeline` orchestrating rules → build → optional registration → optional validation → `GenerationResult`.
+	- `from_context()` classmethods on `World`, `Actor`, `Strategy`, and `Goal`.
+	- Four runnable demo scenarios in `generation/examples.py`.
+12. Quality gate:
+	- Automated tests in `tests/ometeotl_core/model/`, `tests/ometeotl_core/generic/`, `tests/ometeotl_core/game/`, `tests/ometeotl_core/io/`, `tests/ometeotl_core/validation/`, and `tests/ometeotl_core/generation/`.
+	- Current baseline: `396` collected tests.
 
 ### Still incomplete or planned
 
-- `src/ometeotl_core/io/` for dedicated import/export workflows.
-- `src/ometeotl_core/generation/` for contextual construction and repair.
 - `src/ometeotl_core/game/` for deeper solver-facing abstractions beyond current utility and ranking primitives.
 - `src/ometeotl_core/examples/` for reference worlds and end-to-end demos.
+- Generation integration testing: a full roundtrip test of the complete chain (context → pipeline → generated objects → IO export → `to_llm_view()` → parse → validate), and a concrete 2-actor game scenario exercising goal-strategy linkage with utility ranking.
 
 ### Current TODO priorities
 
-1. Implement dedicated IO workflows.
-2. Implement contextual generation and repair.
-3. Implement the game layer.
-4. Extend the strategy layer to support one-action-to-many-outcomes branching with branch-specific projected successor perceptions.
-5. Add examples and end-to-end demonstrations.
-- `src/ometeotl_core/examples/`
+1. Add a full generation roundtrip integration test covering the complete chain: context → pipeline → generated objects → IO export → `to_llm_view()` → parse → validate. Add a concrete 2-actor game scenario wiring goals, strategies, and utility ranking end to end.
+2. Extend the game layer beyond the current utility/ranking primitives with solver-facing structures.
+3. Extend the strategy layer to support one-action-to-many-outcomes branching with branch-specific projected successor perceptions.
+4. Add examples and end-to-end demonstrations.

--- a/specs_EN.md
+++ b/specs_EN.md
@@ -107,9 +107,9 @@ V1 must first demonstrate the system core with a reduced but complete scope: abs
 5. Minimal game-theory interface.
 6. Two examples: a simple world and a hierarchical multi-actor case.
 
-## Current repository state (April 2026)
+## Current repository state (May 2026)
 
-The project is no longer limited to a model/perception/sensor skeleton. It now contains a broader functional V1-incremental core with tested model, projection, strategy, teleology/utility, game-layer ranking, and authority/runtime boundaries.
+The project delivers a broad functional V1 core. All layers from model through validation, IO, LLM export, and contextual generation are implemented and tested.
 
 **04/25/26 - major architectural overhaul:**
   Local tests reveal the current architecture is too abstract for any practical implementation. It has been decided to :
@@ -169,18 +169,32 @@ The project is no longer limited to a model/perception/sensor skeleton. It now c
     - Diagnostic and repair suggestions through `DiagnosticBuilder`.
 12. Minimum interfaces in `src/ometeotl_core/model/interfaces.py`:
     - `Serializable`, `Validatable`, `LLMExportable`, `ContextualBuildable`.
-13. Quality gate:
-    - Automated tests in `tests/ometeotl_core/model/`, `tests/ometeotl_core/generic/`, `tests/ometeotl_core/game/`, `tests/ometeotl_core/io/`, and `tests/ometeotl_core/validation/`.
-    - Current baseline: `317` collected tests.
+13. IO layer in `src/ometeotl_core/io/`:
+    - Canonical JSON and YAML world export (`world_to_json`, `world_to_yaml`, `write_world_json`, `write_world_yaml`).
+    - Validated world import (`world_from_json`, `world_from_yaml`, `WorldImportResult`).
+    - LLM/SLM view exporter (`llm_export.py`) implementing F-5: `world_to_llm_view`, `actor_to_llm_view`, `perception_to_llm_view`, and `ModelObject.to_llm_view()` with explicit reality/perception/belief/hypothesis/projection separation.
+14. Generation layer in `src/ometeotl_core/generation/`:
+    - `GenerationContext` declarative input dataclass with nested child contexts, placement instructions, constraint declarations, and `copy_with` for rule-safe mutation.
+    - `GenerationPlacement` for explicit object-to-space placement in world generation.
+    - Class-based `ContextualBuilder` ABC with concrete builders for all core kinds (`WorldContextualBuilder`, `ActorContextualBuilder`, `StrategyContextualBuilder`, `GoalContextualBuilder`, `PerceptionContextualBuilder`).
+    - Pluggable `GenerationRule` / `GenerationRuleSet` / `RuleRegistry` rule engine.
+    - Built-in constraint propagation rules: `temporal_constraint_rules`, `spatial_constraint_rules`, `admissibility_constraint_rules`, and `combined_generation_rules`.
+    - `default_rule_registry()` pre-populated with `"default"`, `"temporal"`, `"spatial"`, `"admissibility"`, `"combined"`.
+    - `LLMGenerationAdapter` for optional provider-agnostic LLM-assisted context refinement with fallback.
+    - `ContextualGenerationPipeline` orchestrating rules → build → optional registration → optional validation → `GenerationResult`.
+    - `from_context()` classmethods on `World`, `Actor`, `Strategy`, and `Goal`.
+    - Four runnable demo scenarios in `generation/examples.py`.
+15. Quality gate:
+    - Automated tests in `tests/ometeotl_core/model/`, `tests/ometeotl_core/generic/`, `tests/ometeotl_core/game/`, `tests/ometeotl_core/io/`, `tests/ometeotl_core/validation/`, and `tests/ometeotl_core/generation/`.
+    - Current baseline: `396` collected tests.
 
 ### Present but still incomplete or scaffolded
 
 The following layers remain incomplete relative to the target architecture and roadmap:
 
-- `src/ometeotl_core/io/` for dedicated import/export workflows.
-- `src/ometeotl_core/generation/` for contextual or LLM-assisted construction.
 - `src/ometeotl_core/game/` for deeper game-theory projection and solver-facing structures beyond the current utility/ranking primitives.
 - `src/ometeotl_core/examples/` for reference worlds and end-to-end demonstrations.
+- Generation integration testing: a full roundtrip test exercising the complete chain (context → pipeline → generated objects → IO export → `to_llm_view()` → parse → validate), and a concrete 2-actor game scenario exercising goal-strategy linkage with utility ranking.
 
 ### Current source layout
 
@@ -193,8 +207,19 @@ ometeotl/
 │       ├── generic/
 │       │   ├── authority.py
 │       │   └── runtime.py
-│       ├── io/                 # planned / partial scaffold
-│       ├── generation/         # planned / partial scaffold
+│       ├── io/
+│       │   ├── exporters.py
+│       │   ├── importers.py
+│       │   └── llm_export.py
+│       ├── generation/
+│       │   ├── builders.py
+│       │   ├── context.py
+│       │   ├── context_builder.py
+│       │   ├── examples.py
+│       │   ├── llm_integration.py
+│       │   ├── pipeline.py
+│       │   ├── rule_engine.py
+│       │   └── rules.py        # backward-compat re-export
 │       ├── game/
 │       │   └── utility.py
 │       ├── validation/
@@ -209,13 +234,14 @@ ometeotl/
 │       │   ├── epistemic.py
 │       │   ├── completeness.py
 │       │   └── diagnostic.py
-│       ├── examples/           # planned / partial scaffold
+│       ├── examples/           # planned
 │       └── model/
 │           ├── actions.py
 │           ├── actors.py
 │           ├── base.py
 │           ├── goals.py
 │           ├── goal_tools.py
+│           ├── interfaces.py
 │           ├── objects.py
 │           ├── perception.py
 │           ├── projection.py
@@ -230,6 +256,7 @@ ometeotl/
 └── tests/ometeotl_core/
     ├── generic/
     ├── game/
+    ├── generation/
     ├── io/
     ├── model/
     └── validation/
@@ -237,15 +264,14 @@ ometeotl/
 
 ### Practical V1 interpretation
 
-V1 is currently validated on the implemented ontology, perception, projection, strategy, teleology/utility, game ranking, authority/runtime seams, and the dedicated validation layer. Generation, IO, richer solver-facing game modules, and reference examples remain on the roadmap.
+V1 is validated on the full chain: ontology, perception, projection, strategy, teleology/utility, game ranking, authority/runtime, validation, IO (JSON/YAML + LLM export), and contextual generation with pluggable rule engine and LLM adapter. The remaining roadmap items are generation integration scenarios (a roundtrip test of the full context-to-validated-output chain, and a concrete 2-actor game world wiring goals, strategies, and utility ranking end to end) and game-layer solver extensions.
 
 ### Current TODO priorities
 
-1. Implement dedicated IO workflows on top of canonical object serialization.
-2. Implement contextual generation and repair workflows.
-3. Extend the game layer beyond the current utility/ranking primitives with solver-facing structures.
-4. Extend the strategy layer to support one-action-to-many-outcomes branching, with branch-specific projected successor perceived states carried by `StrategyOutcomeBranch` rather than by `StrategyNode`.
-5. Add reference examples and complete end-to-end demos.
+1. Add a full generation roundtrip integration test covering the complete chain: context → pipeline → generated objects → IO export → `to_llm_view()` → parse → validate. Add a concrete 2-actor game scenario wiring goals, strategies, and utility ranking end to end.
+2. Extend the game layer beyond the current utility/ranking primitives with solver-facing structures.
+3. Extend the strategy layer to support one-action-to-many-outcomes branching, with branch-specific projected successor perceived states carried by `StrategyOutcomeBranch` rather than by `StrategyNode`.
+4. Add reference examples and complete end-to-end demos.
 
 
 ## Status

--- a/specs_FR.md
+++ b/specs_FR.md
@@ -108,19 +108,19 @@ La V1 doit d’abord démontrer le cœur du système avec un périmètre réduit
 6. - **Deux exemples** : un monde simple et un cas multi-acteurs hiérarchique.
 
 
-## État actuel du dépôt (avril 2026)
+## État actuel du dépôt (mai 2026)
 
-Le projet n'est plus limité à un cœur model/perception/sensor minimal. Il dispose désormais d'un noyau V1 incrémental plus large, testé, couvrant le modèle, la projection, les stratégies, la téléologie/utilité, le ranking game, ainsi que la frontière d'autorité/runtime.
+Le projet dispose d'un large cœur fonctionnel V1. Toutes les couches, du modèle à la validation, de l'IO à l'export LLM et au pipeline de génération contextuelle, sont implémentées et testées.
 
 **25/04/26 - refonte architecturale majeure :**
-Les tests locaux révèlent que l’architecture actuelle est trop abstraite pour toute implémentation pratique. Il a été décidé de :
+Les tests locaux révèlent que l'architecture actuelle est trop abstraite pour toute implémentation pratique. Il a été décidé de :
 
 - conserver le code actuel dans un module central `ometeotl_core`, qui doit rester abstrait ;
 - ajouter une couche principale de spécialisation `ometeotl_foundations`, incluant :
-    - spatial : première couche d’implémentation spatiale de `ometeotl_core` ;
-    - networks : première couche d’implémentation en théorie des graphes de `ometeotl_core` ;
+    - spatial : première couche d'implémentation spatiale de `ometeotl_core` ;
+    - networks : première couche d'implémentation en théorie des graphes de `ometeotl_core` ;
     - ...
-- ajouter enfin une couche d’adaptateurs `ometeotl_adapters`, qui implémente chaque couche de spécialisation avec une bibliothèque reconnue.
+- ajouter enfin une couche d'adaptateurs `ometeotl_adapters`, qui implémente chaque couche de spécialisation avec une bibliothèque reconnue.
 
 ### Implémenté et testé aujourd'hui
 
@@ -171,18 +171,32 @@ Les tests locaux révèlent que l’architecture actuelle est trop abstraite pou
     - Diagnostics et suggestions de réparation via `DiagnosticBuilder`.
 12. Interfaces minimales dans `src/ometeotl_core/model/interfaces.py` :
     - `Serializable`, `Validatable`, `LLMExportable`, `ContextualBuildable`.
-13. Contrôle qualité :
-    - Tests automatisés dans `tests/ometeotl_core/model/`, `tests/ometeotl_core/generic/`, `tests/ometeotl_core/game/`, `tests/ometeotl_core/io/` et `tests/ometeotl_core/validation/`.
-    - Base actuelle : `317` tests collectés.
+13. Couche IO dans `src/ometeotl_core/io/` :
+    - Export mondial JSON et YAML canonique (`world_to_json`, `world_to_yaml`, `write_world_json`, `write_world_yaml`).
+    - Import mondial validé (`world_from_json`, `world_from_yaml`, `WorldImportResult`).
+    - Exporteur de vue LLM/SLM (`llm_export.py`) implémentant F-5 : `world_to_llm_view`, `actor_to_llm_view`, `perception_to_llm_view`, et `ModelObject.to_llm_view()` avec séparation explicite réalité/perception/croyance/hypothèse/projection.
+14. Couche de génération dans `src/ometeotl_core/generation/` :
+    - `GenerationContext` dataclass d'entrée déclarative avec contextes enfants imbriqués, instructions de placement, déclarations de contraintes, et `copy_with` pour mutation sûre dans les règles.
+    - `GenerationPlacement` pour le placement explicite d'objets dans des espaces lors de la génération de mondes.
+    - ABC `ContextualBuilder` orientée classe avec builders concrets pour tous les types de base (`WorldContextualBuilder`, `ActorContextualBuilder`, `StrategyContextualBuilder`, `GoalContextualBuilder`, `PerceptionContextualBuilder`).
+    - Moteur de règles `GenerationRule` / `GenerationRuleSet` / `RuleRegistry` enfichable.
+    - Règles de propagation de contraintes intégrées : `temporal_constraint_rules`, `spatial_constraint_rules`, `admissibility_constraint_rules`, et `combined_generation_rules`.
+    - `default_rule_registry()` pré-rempli avec `"default"`, `"temporal"`, `"spatial"`, `"admissibility"`, `"combined"`.
+    - `LLMGenerationAdapter` pour le raffinement de contexte assisté par LLM optionnel, agnostique vis-à-vis du fournisseur, avec fallback.
+    - `ContextualGenerationPipeline` orchestrant règles → construction → enregistrement optionnel → validation optionnelle → `GenerationResult`.
+    - Méthodes de classe `from_context()` sur `World`, `Actor`, `Strategy`, et `Goal`.
+    - Quatre scénarios de démonstration exécutables dans `generation/examples.py`.
+15. Contrôle qualité :
+    - Tests automatisés dans `tests/ometeotl_core/model/`, `tests/ometeotl_core/generic/`, `tests/ometeotl_core/game/`, `tests/ometeotl_core/io/`, `tests/ometeotl_core/validation/`, et `tests/ometeotl_core/generation/`.
+    - Base actuelle : `396` tests collectés.
 
 ### Présent mais encore incomplet ou partiellement scaffoldé
 
 Les couches suivantes restent incomplètes au regard de l'architecture cible et de la roadmap :
 
-- `src/ometeotl_core/io/` pour les workflows dédiés d'import/export.
-- `src/ometeotl_core/generation/` pour la construction contextuelle ou assistée par LLM.
 - `src/ometeotl_core/game/` pour des abstractions game orientées solveurs plus riches au-delà des primitives actuelles utilité/ranking.
 - `src/ometeotl_core/examples/` pour les mondes de référence et démonstrations de bout en bout.
+- Tests d'intégration de la génération : un test de bout en bout couvrant la chaîne complète (contexte → pipeline → objets générés → export IO → `to_llm_view()` → parse → validate), et un scénario de jeu concret à 2 acteurs câblant objectifs, stratégies et classement d'utilité.
 
 ### Arborescence source actuelle
 
@@ -193,8 +207,19 @@ ometeotl/
 │       ├── generic/
 │       │   ├── authority.py
 │       │   └── runtime.py
-│       ├── io/                 # prévu / scaffold partiel
-│       ├── generation/         # prévu / scaffold partiel
+│       ├── io/
+│       │   ├── exporters.py
+│       │   ├── importers.py
+│       │   └── llm_export.py
+│       ├── generation/
+│       │   ├── builders.py
+│       │   ├── context.py
+│       │   ├── context_builder.py
+│       │   ├── examples.py
+│       │   ├── llm_integration.py
+│       │   ├── pipeline.py
+│       │   ├── rule_engine.py
+│       │   └── rules.py        # ré-export compat ascendante
 │       ├── game/
 │       │   └── utility.py
 │       ├── validation/
@@ -209,13 +234,14 @@ ometeotl/
 │       │   ├── epistemic.py
 │       │   ├── completeness.py
 │       │   └── diagnostic.py
-│       ├── examples/           # prévu / scaffold partiel
+│       ├── examples/           # prévu
 │       └── model/
 │           ├── actions.py
 │           ├── actors.py
 │           ├── base.py
 │           ├── goals.py
 │           ├── goal_tools.py
+│           ├── interfaces.py
 │           ├── objects.py
 │           ├── perception.py
 │           ├── projection.py
@@ -230,6 +256,7 @@ ometeotl/
 └── tests/ometeotl_core/
     ├── generic/
     ├── game/
+    ├── generation/
     ├── io/
     ├── model/
     └── validation/
@@ -237,16 +264,14 @@ ometeotl/
 
 ### Lecture pratique de la V1
 
-La V1 est actuellement validée sur les coutures ontologiques, perceptives, projectives, stratégiques, téléologie/utilité, ranking game, runtime/autorité, et la couche validation dédiée. Les couches génération, IO dédiées, les modules game orientés solveurs plus riches, et les exemples de référence restent au roadmap.
+La V1 est validée sur la chaîne complète : ontologie, perception, projection, stratégie, téléologie/utilité, ranking game, autorité/runtime, validation, IO (JSON/YAML + export LLM), et génération contextuelle avec moteur de règles enfichable et adaptateur LLM. Les éléments restants de la roadmap sont les tests d'intégration de la génération (test de la chaîne complète contexte-vers-sortie-validée, et un monde de jeu concret à 2 acteurs câblant objectifs, stratégies et classement d'utilité) et les extensions de solveur pour la couche game.
 
 ### Priorités TODO actuelles
 
-1. Implémenter des workflows IO dédiés au-dessus de la sérialisation canonique des objets.
-2. Implémenter la génération contextuelle et les workflows de réparation.
-3. Étendre la couche game au-delà des primitives actuelles utilité/ranking avec des structures orientées solveurs.
-4. Étendre la couche stratégie pour supporter un branchement où une seule action produit plusieurs issues projetées, avec des états perceptifs successeurs portés par `StrategyOutcomeBranch` plutôt que par `StrategyNode`.
-5. Ajouter des exemples de référence et des démos complètes de bout en bout.
-
+1. Ajouter un test d'intégration de bout en bout couvrant la chaîne complète : contexte → pipeline → objets générés → export IO → `to_llm_view()` → parse → validate. Ajouter un scénario de jeu concret à 2 acteurs câblant objectifs, stratégies et classement d'utilité.
+2. Étendre la couche game au-delà des primitives actuelles utilité/ranking avec des structures orientées solveurs.
+3. Étendre la couche stratégie pour supporter un branchement où une seule action produit plusieurs issues projetées, avec des états perceptifs successeurs portés par `StrategyOutcomeBranch` plutôt que par `StrategyNode`.
+4. Ajouter des exemples de référence et des démos complètes de bout en bout.
 
 ## Status
 Le document `specs_EN.md` est la source de vérité pour l'architecture et le comportement du module.

--- a/src/ometeotl_core/generation/__init__.py
+++ b/src/ometeotl_core/generation/__init__.py
@@ -13,7 +13,17 @@ from .context_builder import (
 )
 from .llm_integration import LLMGenerationAdapter, LLMRefinementResult
 from .pipeline import ContextualGenerationPipeline, GenerationResult
-from .rules import GenerationRule, GenerationRuleSet, default_generation_rules
+from .rule_engine import (
+    GenerationRule,
+    GenerationRuleSet,
+    RuleRegistry,
+    admissibility_constraint_rules,
+    combined_generation_rules,
+    default_generation_rules,
+    default_rule_registry,
+    spatial_constraint_rules,
+    temporal_constraint_rules,
+)
 
 __all__ = [
     "GenerationContext",
@@ -29,6 +39,12 @@ __all__ = [
     "build_with_context_builder",
     "GenerationRule",
     "GenerationRuleSet",
+    "RuleRegistry",
+    "temporal_constraint_rules",
+    "spatial_constraint_rules",
+    "admissibility_constraint_rules",
+    "combined_generation_rules",
+    "default_rule_registry",
     "ContextualGenerationPipeline",
     "LLMGenerationAdapter",
     "LLMRefinementResult",

--- a/src/ometeotl_core/generation/__init__.py
+++ b/src/ometeotl_core/generation/__init__.py
@@ -1,6 +1,16 @@
 """Contextual generation API for ometeotl_core."""
 
 from .context import GenerationContext, GenerationPlacement
+from .context_builder import (
+    ActorContextualBuilder,
+    ContextualBuilder,
+    GoalContextualBuilder,
+    PerceptionContextualBuilder,
+    StrategyContextualBuilder,
+    WorldContextualBuilder,
+    build_with_context_builder,
+    default_contextual_builders,
+)
 from .llm_integration import LLMGenerationAdapter, LLMRefinementResult
 from .pipeline import ContextualGenerationPipeline, GenerationResult
 from .rules import GenerationRule, GenerationRuleSet, default_generation_rules
@@ -9,6 +19,14 @@ __all__ = [
     "GenerationContext",
     "GenerationPlacement",
     "GenerationResult",
+    "ContextualBuilder",
+    "WorldContextualBuilder",
+    "ActorContextualBuilder",
+    "StrategyContextualBuilder",
+    "GoalContextualBuilder",
+    "PerceptionContextualBuilder",
+    "default_contextual_builders",
+    "build_with_context_builder",
     "GenerationRule",
     "GenerationRuleSet",
     "ContextualGenerationPipeline",

--- a/src/ometeotl_core/generation/__init__.py
+++ b/src/ometeotl_core/generation/__init__.py
@@ -1,15 +1,18 @@
 """Contextual generation API for ometeotl_core."""
 
 from .context import GenerationContext, GenerationPlacement
+from .llm_integration import LLMGenerationAdapter, LLMRefinementResult
 from .pipeline import ContextualGenerationPipeline, GenerationResult
 from .rules import GenerationRule, GenerationRuleSet, default_generation_rules
 
 __all__ = [
-	"GenerationContext",
-	"GenerationPlacement",
-	"GenerationResult",
-	"GenerationRule",
-	"GenerationRuleSet",
-	"ContextualGenerationPipeline",
-	"default_generation_rules",
+    "GenerationContext",
+    "GenerationPlacement",
+    "GenerationResult",
+    "GenerationRule",
+    "GenerationRuleSet",
+    "ContextualGenerationPipeline",
+    "LLMGenerationAdapter",
+    "LLMRefinementResult",
+    "default_generation_rules",
 ]

--- a/src/ometeotl_core/generation/builders.py
+++ b/src/ometeotl_core/generation/builders.py
@@ -51,9 +51,12 @@ def build_goal(context: GenerationContext) -> Goal:
         context.metadata.get("actor_id") or context.context.get("actor_id") or ""
     )
     kind = str(context.metadata.get("kind") or context.context.get("kind") or "final")
-    priority = float(
-        context.metadata.get("priority") or context.context.get("priority") or 1.0
-    )
+    priority_val = context.metadata.get("priority")
+    if priority_val is None:
+        priority_val = context.context.get("priority")
+    if priority_val is None:
+        priority_val = 1.0
+    priority = float(priority_val)
     status = str(
         context.metadata.get("status") or context.context.get("status") or "active"
     )

--- a/src/ometeotl_core/generation/builders.py
+++ b/src/ometeotl_core/generation/builders.py
@@ -1,0 +1,330 @@
+"""Object builders for contextual generation."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ometeotl_core.model.actions import Action
+from ometeotl_core.model.actors import Actor
+from ometeotl_core.model.goals import Goal
+from ometeotl_core.model.perception import (
+    Perception,
+    PerceivedComponentLink,
+    PerceivedMembership,
+    PerceivedRelation,
+    PerceivedSpace,
+)
+from ometeotl_core.model.resources import Resource
+from ometeotl_core.model.space_relations import SpaceRelation
+from ometeotl_core.model.spaces import Space, SpaceObjectMembership
+from ometeotl_core.model.strategies import Strategy, StrategyNode
+from ometeotl_core.model.world import World
+
+from .context import GenerationContext
+
+
+def _base_kwargs(context: GenerationContext) -> dict[str, Any]:
+    return {
+        "id": context.id,
+        "attributes": context.merged_attributes(),
+        "relations": context.normalized_relations(),
+        "state": dict(context.state),
+        "context": context.merged_context(),
+        "provenance": dict(context.provenance),
+    }
+
+
+def build_space(context: GenerationContext) -> Space:
+    return Space(**_base_kwargs(context))
+
+
+def build_actor(context: GenerationContext) -> Actor:
+    return Actor(**_base_kwargs(context))
+
+
+def build_resource(context: GenerationContext) -> Resource:
+    return Resource(**_base_kwargs(context))
+
+
+def build_goal(context: GenerationContext) -> Goal:
+    actor_id = str(
+        context.metadata.get("actor_id") or context.context.get("actor_id") or ""
+    )
+    kind = str(context.metadata.get("kind") or context.context.get("kind") or "final")
+    priority = float(
+        context.metadata.get("priority") or context.context.get("priority") or 1.0
+    )
+    status = str(
+        context.metadata.get("status") or context.context.get("status") or "active"
+    )
+    horizon = dict(
+        context.metadata.get("horizon") or context.context.get("horizon") or {}
+    )
+    target_condition = dict(
+        context.metadata.get("target_condition")
+        or context.context.get("target_condition")
+        or {}
+    )
+    if not actor_id:
+        raise ValueError(
+            "Goal generation requires actor_id in context.metadata or context.context"
+        )
+
+    return Goal(
+        **_base_kwargs(context),
+        actor_id=actor_id,
+        kind=kind,
+        priority=priority,
+        status=status,
+        horizon=horizon,
+        target_condition=target_condition,
+    )
+
+
+def build_strategy(context: GenerationContext) -> Strategy:
+    actor_id = str(
+        context.metadata.get("actor_id") or context.context.get("actor_id") or ""
+    )
+    root_node_id = str(
+        context.metadata.get("root_node_id")
+        or context.context.get("root_node_id")
+        or "root"
+    )
+    goal_id_raw = context.metadata.get("goal_id") or context.context.get("goal_id")
+    projection_policy = str(
+        context.metadata.get("projection_policy")
+        or context.context.get("projection_policy")
+        or "perception_first"
+    )
+    action_id = str(
+        context.metadata.get("action_id")
+        or context.context.get("action_id")
+        or f"action-{context.id}"
+    )
+
+    if not actor_id:
+        raise ValueError(
+            "Strategy generation requires actor_id in context.metadata or context.context"
+        )
+
+    node = StrategyNode(node_id=root_node_id, action_id=action_id)
+    strategy = Strategy(
+        **_base_kwargs(context),
+        actor_id=actor_id,
+        goal_id=str(goal_id_raw) if goal_id_raw else None,
+        root_node_id=root_node_id,
+        nodes=[node],
+        projection_policy=projection_policy,
+    )
+    strategy.add_relation("action", action_id)
+    return strategy
+
+
+def build_action(context: GenerationContext) -> Action:
+    actor_id = str(
+        context.metadata.get("actor_id") or context.context.get("actor_id") or ""
+    )
+    world_id = str(
+        context.metadata.get("world_id") or context.context.get("world_id") or ""
+    )
+    space_id = str(
+        context.metadata.get("space_id") or context.context.get("space_id") or ""
+    )
+    action_type = str(
+        context.metadata.get("action_type")
+        or context.context.get("action_type")
+        or "generic"
+    )
+
+    if not actor_id or not world_id or not space_id:
+        raise ValueError(
+            "Action generation requires actor_id, world_id, and space_id in metadata/context"
+        )
+
+    return Action(
+        **_base_kwargs(context),
+        actor_id=actor_id,
+        world_id=world_id,
+        space_id=space_id,
+        action_type=action_type,
+    )
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def build_perception(context: GenerationContext) -> Perception:
+    actor_id = str(
+        context.metadata.get("actor_id") or context.context.get("actor_id") or ""
+    )
+    source_id = str(
+        context.metadata.get("source_id") or context.context.get("source_id") or ""
+    )
+    timestamp = context.metadata.get("timestamp", context.context.get("timestamp"))
+
+    if not actor_id or not source_id:
+        raise ValueError(
+            "Perception generation requires actor_id and source_id in metadata/context"
+        )
+
+    raw_spaces = _as_mapping(
+        context.metadata.get("perceived_spaces")
+        or context.context.get("perceived_spaces")
+    )
+    perceived_spaces: dict[str, PerceivedSpace] = {}
+    for space_id, payload in sorted(raw_spaces.items()):
+        if isinstance(payload, PerceivedSpace):
+            perceived_spaces[str(space_id)] = payload
+            continue
+
+        payload_map = _as_mapping(payload)
+        raw_space = payload_map.get("space")
+        if isinstance(raw_space, Space):
+            space = raw_space
+        elif isinstance(raw_space, Mapping):
+            space = Space.from_dict(raw_space)
+        else:
+            space = Space(id=str(raw_space or space_id))
+
+        perceived_spaces[str(space_id)] = PerceivedSpace(
+            space=space,
+            epistemic_status=str(payload_map.get("epistemic_status") or "certain"),
+            noise_metadata=dict(payload_map.get("noise_metadata") or {}),
+        )
+
+    raw_memberships = (
+        context.metadata.get("perceived_memberships")
+        or context.context.get("perceived_memberships")
+        or []
+    )
+    perceived_memberships: list[PerceivedMembership] = []
+    for payload in raw_memberships:
+        if isinstance(payload, PerceivedMembership):
+            perceived_memberships.append(payload)
+            continue
+
+        payload_map = _as_mapping(payload)
+        raw_membership = payload_map.get("membership")
+        if isinstance(raw_membership, SpaceObjectMembership):
+            membership = raw_membership
+        else:
+            membership_map = _as_mapping(raw_membership)
+            membership = SpaceObjectMembership.from_dict(membership_map)
+
+        perceived_memberships.append(
+            PerceivedMembership(
+                membership=membership,
+                epistemic_status=str(payload_map.get("epistemic_status") or "certain"),
+                noise_metadata=dict(payload_map.get("noise_metadata") or {}),
+            )
+        )
+
+    raw_relations = (
+        context.metadata.get("perceived_relations")
+        or context.context.get("perceived_relations")
+        or []
+    )
+    perceived_relations: list[PerceivedRelation] = []
+    for payload in raw_relations:
+        if isinstance(payload, PerceivedRelation):
+            perceived_relations.append(payload)
+            continue
+
+        payload_map = _as_mapping(payload)
+        raw_relation = payload_map.get("relation")
+        if isinstance(raw_relation, SpaceRelation):
+            relation = raw_relation
+        else:
+            relation_map = _as_mapping(raw_relation)
+            relation = SpaceRelation.from_dict(relation_map)
+
+        perceived_relations.append(
+            PerceivedRelation(
+                relation=relation,
+                epistemic_status=str(payload_map.get("epistemic_status") or "certain"),
+                noise_metadata=dict(payload_map.get("noise_metadata") or {}),
+            )
+        )
+
+    raw_component_links = (
+        context.metadata.get("perceived_component_links")
+        or context.context.get("perceived_component_links")
+        or []
+    )
+    perceived_component_links: list[PerceivedComponentLink] = []
+    for payload in raw_component_links:
+        if isinstance(payload, PerceivedComponentLink):
+            perceived_component_links.append(payload)
+            continue
+
+        payload_map = _as_mapping(payload)
+        perceived_component_links.append(
+            PerceivedComponentLink(
+                link_id=str(payload_map.get("link_id") or ""),
+                composite_id=str(payload_map.get("composite_id") or ""),
+                component_id=str(payload_map.get("component_id") or ""),
+                epistemic_status=str(payload_map.get("epistemic_status") or "certain"),
+                noise_metadata=dict(payload_map.get("noise_metadata") or {}),
+            )
+        )
+
+    return Perception(
+        id=context.id,
+        actor_id=actor_id,
+        source_id=source_id,
+        schema_version="1.0",
+        timestamp=timestamp,
+        perceived_spaces=perceived_spaces,
+        perceived_memberships=perceived_memberships,
+        perceived_relations=perceived_relations,
+        perceived_component_links=perceived_component_links,
+        context=context.merged_context(),
+        provenance=dict(context.provenance),
+    )
+
+
+def build_world(context: GenerationContext) -> World:
+    world = World(
+        id=context.id,
+        attributes=context.merged_attributes(),
+        relations=context.normalized_relations(),
+        state=dict(context.state),
+        context=context.merged_context(),
+        provenance=dict(context.provenance),
+    )
+
+    for space_context in context.spaces:
+        world.add_space(build_space(space_context))
+
+    for actor_context in context.actors:
+        world.register_object(build_actor(actor_context))
+
+    for resource_context in context.resources:
+        world.register_object(build_resource(resource_context))
+
+    for placement in context.placements:
+        world.place_object(placement.object_id, placement.space_id, role=placement.role)
+
+    return world
+
+
+def build_from_context(context: GenerationContext) -> Any:
+    kind = context.kind.lower().strip()
+    if kind == "world":
+        return build_world(context)
+    if kind == "space":
+        return build_space(context)
+    if kind == "actor":
+        return build_actor(context)
+    if kind == "resource":
+        return build_resource(context)
+    if kind == "goal":
+        return build_goal(context)
+    if kind == "strategy":
+        return build_strategy(context)
+    if kind == "action":
+        return build_action(context)
+    if kind == "perception":
+        return build_perception(context)
+    raise ValueError(f"Unsupported generation kind: {context.kind}")

--- a/src/ometeotl_core/generation/builders.py
+++ b/src/ometeotl_core/generation/builders.py
@@ -154,6 +154,15 @@ def _as_mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
 
 
+def _require_non_empty_string(value: Any, field_name: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(
+            f"Perception generation requires non-empty '{field_name}' in perceived_component_links"
+        )
+    return normalized
+
+
 def build_perception(context: GenerationContext) -> Perception:
     actor_id = str(
         context.metadata.get("actor_id") or context.context.get("actor_id") or ""
@@ -261,9 +270,17 @@ def build_perception(context: GenerationContext) -> Perception:
         payload_map = _as_mapping(payload)
         perceived_component_links.append(
             PerceivedComponentLink(
-                link_id=str(payload_map.get("link_id") or ""),
-                composite_id=str(payload_map.get("composite_id") or ""),
-                component_id=str(payload_map.get("component_id") or ""),
+                link_id=_require_non_empty_string(
+                    payload_map.get("link_id"), "link_id"
+                ),
+                composite_id=_require_non_empty_string(
+                    payload_map.get("composite_id"),
+                    "composite_id",
+                ),
+                component_id=_require_non_empty_string(
+                    payload_map.get("component_id"),
+                    "component_id",
+                ),
                 epistemic_status=str(payload_map.get("epistemic_status") or "certain"),
                 noise_metadata=dict(payload_map.get("noise_metadata") or {}),
             )

--- a/src/ometeotl_core/generation/builders.py
+++ b/src/ometeotl_core/generation/builders.py
@@ -218,10 +218,18 @@ def build_perception(context: GenerationContext) -> Perception:
 
         payload_map = _as_mapping(payload)
         raw_membership = payload_map.get("membership")
+        if raw_membership is None:
+            raise ValueError(
+                "Perception generation requires 'membership' payload in perceived_memberships"
+            )
         if isinstance(raw_membership, SpaceObjectMembership):
             membership = raw_membership
         else:
             membership_map = _as_mapping(raw_membership)
+            if not membership_map:
+                raise ValueError(
+                    "Perception generation requires non-empty 'membership' mapping in perceived_memberships"
+                )
             membership = SpaceObjectMembership.from_dict(membership_map)
 
         perceived_memberships.append(

--- a/src/ometeotl_core/generation/context.py
+++ b/src/ometeotl_core/generation/context.py
@@ -49,6 +49,8 @@ class GenerationContext:
     actions: list["GenerationContext"] = field(default_factory=list)
     placements: list[GenerationPlacement] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
+    rules: dict[str, Any] = field(default_factory=dict)
+    constraints: dict[str, Any] = field(default_factory=dict)
     operation: str = "create"
     target_id: str = ""
     registration_policy: str = "none"
@@ -77,10 +79,14 @@ class GenerationContext:
     def merged_context(self) -> dict[str, Any]:
         """Return context metadata enriched with the generation payload."""
         merged = dict(self.context)
-        if self.metadata:
+        if self.metadata or self.rules or self.constraints:
             merged.setdefault("generation", {})
             generation_metadata = dict(merged["generation"])
             generation_metadata.update(self.metadata)
+            if self.rules:
+                generation_metadata.setdefault("rules", dict(self.rules))
+            if self.constraints:
+                generation_metadata.setdefault("constraints", dict(self.constraints))
             merged["generation"] = generation_metadata
         return merged
 
@@ -110,6 +116,8 @@ class GenerationContext:
             "actions": list(self.actions),
             "placements": list(self.placements),
             "metadata": dict(self.metadata),
+            "rules": dict(self.rules),
+            "constraints": dict(self.constraints),
             "operation": self.operation,
             "target_id": self.target_id,
             "registration_policy": self.registration_policy,

--- a/src/ometeotl_core/generation/context.py
+++ b/src/ometeotl_core/generation/context.py
@@ -49,6 +49,9 @@ class GenerationContext:
     actions: list["GenerationContext"] = field(default_factory=list)
     placements: list[GenerationPlacement] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
+    operation: str = "create"
+    target_id: str = ""
+    registration_policy: str = "none"
     validate: bool = False
     validation_mode: str = "lenient"
     stage_modes: dict[str, str] = field(default_factory=dict)
@@ -107,6 +110,9 @@ class GenerationContext:
             "actions": list(self.actions),
             "placements": list(self.placements),
             "metadata": dict(self.metadata),
+            "operation": self.operation,
+            "target_id": self.target_id,
+            "registration_policy": self.registration_policy,
             "validate": self.validate,
             "validation_mode": self.validation_mode,
             "stage_modes": dict(self.stage_modes),

--- a/src/ometeotl_core/generation/context.py
+++ b/src/ometeotl_core/generation/context.py
@@ -1,0 +1,115 @@
+"""Generation context primitives for ometeotl_core.
+
+The generation layer stays intentionally lightweight: it defines a
+small, structured context object that can be turned into model objects by the
+pipeline without pushing business logic into the model layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class GenerationPlacement:
+    """Explicit placement instruction used when generating a world."""
+
+    object_id: str
+    space_id: str
+    role: str = "occupies"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "object_id": self.object_id,
+            "space_id": self.space_id,
+            "role": self.role,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass
+class GenerationContext:
+    """Declarative input used to generate one model object."""
+
+    kind: str
+    id: str
+    label: str = ""
+    attributes: dict[str, Any] = field(default_factory=dict)
+    relations: dict[str, list[str]] = field(default_factory=dict)
+    state: dict[str, Any] = field(default_factory=dict)
+    context: dict[str, Any] = field(default_factory=dict)
+    provenance: dict[str, Any] = field(default_factory=dict)
+    spaces: list["GenerationContext"] = field(default_factory=list)
+    actors: list["GenerationContext"] = field(default_factory=list)
+    resources: list["GenerationContext"] = field(default_factory=list)
+    goals: list["GenerationContext"] = field(default_factory=list)
+    strategies: list["GenerationContext"] = field(default_factory=list)
+    actions: list["GenerationContext"] = field(default_factory=list)
+    placements: list[GenerationPlacement] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    validate: bool = False
+    validation_mode: str = "lenient"
+    stage_modes: dict[str, str] = field(default_factory=dict)
+
+    def child_collections(self) -> dict[str, list["GenerationContext"]]:
+        """Return the nested context collections in one stable mapping."""
+        return {
+            "spaces": list(self.spaces),
+            "actors": list(self.actors),
+            "resources": list(self.resources),
+            "goals": list(self.goals),
+            "strategies": list(self.strategies),
+            "actions": list(self.actions),
+        }
+
+    def merged_attributes(self) -> dict[str, Any]:
+        """Return attributes with the label promoted when present."""
+        merged = dict(self.attributes)
+        if self.label and "label" not in merged:
+            merged["label"] = self.label
+        return merged
+
+    def merged_context(self) -> dict[str, Any]:
+        """Return context metadata enriched with the generation payload."""
+        merged = dict(self.context)
+        if self.metadata:
+            merged.setdefault("generation", {})
+            generation_metadata = dict(merged["generation"])
+            generation_metadata.update(self.metadata)
+            merged["generation"] = generation_metadata
+        return merged
+
+    def normalized_relations(self) -> dict[str, list[str]]:
+        """Return deterministic relation lists with duplicates removed."""
+        normalized: dict[str, list[str]] = {}
+        for key, values in self.relations.items():
+            normalized[key] = sorted({str(value) for value in values if value})
+        return normalized
+
+    def copy_with(self, **changes: Any) -> "GenerationContext":
+        """Return a modified copy of this generation context."""
+        data = {
+            "kind": self.kind,
+            "id": self.id,
+            "label": self.label,
+            "attributes": dict(self.attributes),
+            "relations": dict(self.relations),
+            "state": dict(self.state),
+            "context": dict(self.context),
+            "provenance": dict(self.provenance),
+            "spaces": list(self.spaces),
+            "actors": list(self.actors),
+            "resources": list(self.resources),
+            "goals": list(self.goals),
+            "strategies": list(self.strategies),
+            "actions": list(self.actions),
+            "placements": list(self.placements),
+            "metadata": dict(self.metadata),
+            "validate": self.validate,
+            "validation_mode": self.validation_mode,
+            "stage_modes": dict(self.stage_modes),
+        }
+        data.update(changes)
+        return GenerationContext(**data)

--- a/src/ometeotl_core/generation/context_builder.py
+++ b/src/ometeotl_core/generation/context_builder.py
@@ -1,0 +1,121 @@
+"""Class-based contextual builders for generation.
+
+This module provides a typed builder abstraction on top of the existing
+function-based builders so callers can compose or override per-kind behavior
+without changing the generation pipeline contract.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+from ometeotl_core.model.actors import Actor
+from ometeotl_core.model.goals import Goal
+from ometeotl_core.model.perception import Perception
+from ometeotl_core.model.strategies import Strategy
+from ometeotl_core.model.world import World
+
+from .builders import (
+    build_actor,
+    build_goal,
+    build_perception,
+    build_strategy,
+    build_world,
+)
+from .context import GenerationContext
+
+TGenerated = TypeVar("TGenerated")
+
+
+class ContextualBuilder(ABC, Generic[TGenerated]):
+    """Base class for kind-specific generation context builders."""
+
+    kind: str
+
+    def ensure_kind(self, context: GenerationContext) -> None:
+        """Validate the context kind routed to this builder."""
+        if str(context.kind).lower().strip() != self.kind:
+            raise ValueError(
+                f"Builder '{self.__class__.__name__}' expects kind '{self.kind}', "
+                f"received '{context.kind}'"
+            )
+
+    @abstractmethod
+    def build(self, context: GenerationContext) -> TGenerated:
+        """Build one object from a generation context."""
+
+
+class WorldContextualBuilder(ContextualBuilder[World]):
+    """Build world objects from generation context."""
+
+    kind = "world"
+
+    def build(self, context: GenerationContext) -> World:
+        self.ensure_kind(context)
+        return build_world(context)
+
+
+class ActorContextualBuilder(ContextualBuilder[Actor]):
+    """Build actor objects from generation context."""
+
+    kind = "actor"
+
+    def build(self, context: GenerationContext) -> Actor:
+        self.ensure_kind(context)
+        return build_actor(context)
+
+
+class StrategyContextualBuilder(ContextualBuilder[Strategy]):
+    """Build strategy objects from generation context."""
+
+    kind = "strategy"
+
+    def build(self, context: GenerationContext) -> Strategy:
+        self.ensure_kind(context)
+        return build_strategy(context)
+
+
+class GoalContextualBuilder(ContextualBuilder[Goal]):
+    """Build goal objects from generation context."""
+
+    kind = "goal"
+
+    def build(self, context: GenerationContext) -> Goal:
+        self.ensure_kind(context)
+        return build_goal(context)
+
+
+class PerceptionContextualBuilder(ContextualBuilder[Perception]):
+    """Build perception objects from generation context."""
+
+    kind = "perception"
+
+    def build(self, context: GenerationContext) -> Perception:
+        self.ensure_kind(context)
+        return build_perception(context)
+
+
+def default_contextual_builders() -> dict[str, ContextualBuilder[Any]]:
+    """Return default builder instances keyed by generation kind."""
+    return {
+        "world": WorldContextualBuilder(),
+        "actor": ActorContextualBuilder(),
+        "strategy": StrategyContextualBuilder(),
+        "goal": GoalContextualBuilder(),
+        "perception": PerceptionContextualBuilder(),
+    }
+
+
+def build_with_context_builder(
+    context: GenerationContext,
+    *,
+    builders: dict[str, ContextualBuilder[Any]] | None = None,
+) -> Any:
+    """Build one object via the class-based builder registry."""
+    builder_map = builders or default_contextual_builders()
+    kind = str(context.kind).lower().strip()
+    builder = builder_map.get(kind)
+    if builder is None:
+        raise ValueError(f"Unsupported generation kind for class-based builder: {kind}")
+    return builder.build(context)

--- a/src/ometeotl_core/generation/examples.py
+++ b/src/ometeotl_core/generation/examples.py
@@ -1,0 +1,237 @@
+"""Runnable demo scenarios for the contextual generation pipeline.
+
+Each function is self-contained and demonstrates one concrete generation
+pattern. Run this module directly to see the output of all four scenarios.
+"""
+
+from __future__ import annotations
+
+from ometeotl_core.generation.context import GenerationContext, GenerationPlacement
+from ometeotl_core.generation.pipeline import ContextualGenerationPipeline
+from ometeotl_core.generation.rule_engine import (
+    default_rule_registry,
+    temporal_constraint_rules,
+)
+from ometeotl_core.model.world import World
+from ometeotl_core.model.actors import Actor
+from ometeotl_core.model.perception import Perception
+from ometeotl_core.model.goals import Goal
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — Simple world: 1 actor, 2 spaces
+# ---------------------------------------------------------------------------
+
+
+def demo_simple_world() -> World:
+    """Generate a minimal world with two spaces and one actor.
+
+    Demonstrates: nested context, placement instructions.
+    """
+    pipeline = ContextualGenerationPipeline()
+
+    ctx = GenerationContext(
+        kind="world",
+        id="world-demo-1",
+        label="Demo World",
+        spaces=[
+            GenerationContext(kind="space", id="space-alpha", label="Alpha"),
+            GenerationContext(kind="space", id="space-beta", label="Beta"),
+        ],
+        actors=[
+            GenerationContext(
+                kind="actor",
+                id="actor-demo-1",
+                label="Explorer",
+                attributes={"role": "explorer"},
+            )
+        ],
+        placements=[
+            GenerationPlacement(
+                object_id="actor-demo-1",
+                space_id="space-alpha",
+                role="occupies",
+            )
+        ],
+    )
+
+    result = pipeline.generate(ctx)
+    world: World = result.generated
+    print("[Scenario 1] Simple world")
+    print(f"  World id       : {world.id}")
+    print(f"  Spaces         : {sorted(world.space_object_graph.spaces.keys())}")
+    print(f"  Objects        : {sorted(world.model_registry.all_ids())}")
+    print(f"  Rules applied  : {result.applied_rule_names}")
+    print()
+    return world
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — Hierarchical multi-actor world with constraint propagation
+# ---------------------------------------------------------------------------
+
+
+def demo_multi_actor_world() -> World:
+    """Generate a world with three actors, two spaces, and temporal constraints.
+
+    Demonstrates: temporal constraint propagation, multiple actors, dedup.
+    """
+    pipeline = ContextualGenerationPipeline()
+
+    ctx = GenerationContext(
+        kind="world",
+        id="world-demo-2",
+        label="Council Arena",
+        constraints={
+            "temporal": {"window": 20, "start_step": 5},
+            "spatial": {"allowed_spaces": ["north", "south", "north"]},
+        },
+        spaces=[
+            GenerationContext(kind="space", id="north", label="North Quarter"),
+            GenerationContext(kind="space", id="south", label="South Quarter"),
+        ],
+        actors=[
+            GenerationContext(
+                kind="actor",
+                id="actor-alpha",
+                label="Alpha",
+                attributes={"faction": "red"},
+            ),
+            GenerationContext(
+                kind="actor",
+                id="actor-beta",
+                label="Beta",
+                attributes={"faction": "blue"},
+            ),
+            GenerationContext(
+                kind="actor",
+                id="actor-gamma",
+                label="Gamma",
+                attributes={"faction": "blue"},
+            ),
+        ],
+        placements=[
+            GenerationPlacement("actor-alpha", "north"),
+            GenerationPlacement("actor-beta", "south"),
+            GenerationPlacement("actor-gamma", "south"),
+        ],
+    )
+
+    result = pipeline.generate(ctx)
+    world: World = result.generated
+    print("[Scenario 2] Hierarchical multi-actor world")
+    print(f"  World id         : {world.id}")
+    print(f"  Spaces           : {sorted(world.space_object_graph.spaces.keys())}")
+    print(f"  Actors           : {sorted(world.model_registry.all_ids())}")
+    print(
+        f"  Allowed spaces   : {result.generated.context.get('generation', {}).get('constraints', {}).get('spatial', {})}"
+    )
+    print(f"  Rules applied    : {result.applied_rule_names}")
+    print()
+    return world
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — Perception generation
+# ---------------------------------------------------------------------------
+
+
+def demo_perception_generation() -> Perception:
+    """Generate a perception object for an actor observing a known space.
+
+    Demonstrates: metadata-driven perception, epistemic status.
+    """
+    registry = default_rule_registry()
+    pipeline = ContextualGenerationPipeline(rules=registry.require("default"))
+
+    ctx = GenerationContext(
+        kind="perception",
+        id="percept-demo-1",
+        label="Observer view",
+        metadata={
+            "actor_id": "actor-observer",
+            "source_id": "world-demo-1",
+            "timestamp": 42,
+            "perceived_spaces": {
+                "space-alpha": {
+                    "space": {"id": "space-alpha"},
+                    "epistemic_status": "certain",
+                    "noise_metadata": {},
+                }
+            },
+        },
+    )
+
+    result = pipeline.generate(ctx)
+    percept: Perception = result.generated
+    print("[Scenario 3] Perception generation")
+    print(f"  Perception id    : {percept.id}")
+    print(f"  Actor id         : {percept.actor_id}")
+    print(f"  Source id        : {percept.source_id}")
+    print(f"  Perceived spaces : {sorted(percept.perceived_spaces.keys())}")
+    print(f"  Rules applied    : {result.applied_rule_names}")
+    print()
+    return percept
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — Goal generation with admissibility constraints
+# ---------------------------------------------------------------------------
+
+
+def demo_goal_generation() -> Goal:
+    """Generate a goal for a specific actor with admissibility constraints.
+
+    Demonstrates: admissibility constraint propagation, goal attributes.
+    """
+    pipeline = ContextualGenerationPipeline()
+
+    ctx = GenerationContext(
+        kind="goal",
+        id="goal-demo-1",
+        label="Reach North Quarter",
+        constraints={
+            "temporal": {"window": 10},
+            "admissibility": {
+                "required_capability": "mobility",
+                "minimum_confidence": 0.75,
+            },
+        },
+        metadata={
+            "actor_id": "actor-alpha",
+            "kind": "final",
+            "priority": 0.9,
+            "status": "active",
+            "target_condition": {"location": "north"},
+        },
+    )
+
+    result = pipeline.generate(ctx)
+    goal: Goal = result.generated
+    print("[Scenario 4] Goal generation with admissibility constraints")
+    print(f"  Goal id              : {goal.id}")
+    print(f"  Actor id             : {goal.actor_id}")
+    print(f"  Kind / Priority      : {goal.kind} / {goal.priority}")
+    print(f"  Target condition     : {goal.target_condition}")
+    print(
+        f"  Required capability  : {result.generated.context.get('generation', {}).get('constraints', {}).get('admissibility', {})}"
+    )
+    print(f"  Rules applied        : {result.applied_rule_names}")
+    print()
+    return goal
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def run_all() -> None:
+    """Run all demo scenarios in sequence."""
+    demo_simple_world()
+    demo_multi_actor_world()
+    demo_perception_generation()
+    demo_goal_generation()
+
+
+if __name__ == "__main__":
+    run_all()

--- a/src/ometeotl_core/generation/llm_integration.py
+++ b/src/ometeotl_core/generation/llm_integration.py
@@ -180,7 +180,17 @@ class LLMGenerationAdapter:
         return overrides
 
     def _parse_json_mapping(self, raw_response: str) -> Mapping[str, Any]:
-        parsed = json.loads(raw_response)
+        cleaned = raw_response.strip()
+        ticks = "`" * 3
+        if cleaned.startswith(ticks):
+            lines = cleaned.splitlines()
+            if lines and lines[0].startswith(ticks):
+                lines = lines[1:]
+            if lines and lines[-1].startswith(ticks):
+                lines = lines[:-1]
+            cleaned = "\n".join(lines).strip()
+
+        parsed = json.loads(cleaned)
         if not isinstance(parsed, Mapping):
             raise ValueError("LLM response must decode to a JSON object")
         return parsed

--- a/src/ometeotl_core/generation/llm_integration.py
+++ b/src/ometeotl_core/generation/llm_integration.py
@@ -181,15 +181,10 @@ class LLMGenerationAdapter:
 
     def _parse_json_mapping(self, raw_response: str) -> Mapping[str, Any]:
         cleaned = raw_response.strip()
-        ticks = "`" * 3
-        if cleaned.startswith(ticks):
-            lines = cleaned.splitlines()
-            if lines and lines[0].startswith(ticks):
-                lines = lines[1:]
-            if lines and lines[-1].startswith(ticks):
-                lines = lines[:-1]
-            cleaned = "\n".join(lines).strip()
-
+        start_idx = cleaned.find("{")
+        end_idx = cleaned.rfind("}")
+        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
+            cleaned = cleaned[start_idx : end_idx + 1]
         parsed = json.loads(cleaned)
         if not isinstance(parsed, Mapping):
             raise ValueError("LLM response must decode to a JSON object")

--- a/src/ometeotl_core/generation/llm_integration.py
+++ b/src/ometeotl_core/generation/llm_integration.py
@@ -79,7 +79,19 @@ class LLMGenerationAdapter:
         returned with diagnostics and used_fallback=True.
         """
         prompt = self.render_prompt(context, prompt_template=prompt_template)
-        raw_response = self._text_generator(prompt)
+        try:
+            raw_response = self._text_generator(prompt)
+        except Exception as exc:  # noqa: BLE001 - provider/runtime exceptions
+            if not fallback_to_base:
+                raise
+            return LLMRefinementResult(
+                refined_context=context,
+                raw_response="",
+                used_fallback=True,
+                diagnostics=[
+                    "LLM generation failed; falling back to base " f"context: {exc}"
+                ],
+            )
 
         return self.refine_context_from_response(
             context,

--- a/src/ometeotl_core/generation/llm_integration.py
+++ b/src/ometeotl_core/generation/llm_integration.py
@@ -1,0 +1,159 @@
+"""LLM-assisted context refinement for hybrid generation workflows.
+
+This module is intentionally provider-agnostic. It accepts a callable text
+producer and converts LLM text responses into deterministic GenerationContext
+updates that can be validated by the regular generation pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+from .context import GenerationContext
+
+TextGenerator = Callable[[str], str]
+ResponseParser = Callable[[str], Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class LLMRefinementResult:
+    """Result of one LLM refinement attempt."""
+
+    refined_context: GenerationContext
+    raw_response: str
+    used_fallback: bool = False
+    diagnostics: list[str] = field(default_factory=list)
+
+
+class LLMGenerationAdapter:
+    """Provider-neutral adapter for context -> prompt -> context refinement."""
+
+    def __init__(
+        self,
+        *,
+        text_generator: TextGenerator,
+        response_parser: ResponseParser | None = None,
+    ) -> None:
+        self._text_generator = text_generator
+        self._response_parser = response_parser or self._parse_json_mapping
+
+    def render_prompt(
+        self,
+        context: GenerationContext,
+        *,
+        prompt_template: str | None = None,
+    ) -> str:
+        """Render a deterministic prompt from a generation context."""
+        context_payload = {
+            "kind": context.kind,
+            "id": context.id,
+            "attributes": dict(context.attributes),
+            "relations": context.normalized_relations(),
+            "state": dict(context.state),
+            "context": dict(context.context),
+            "metadata": dict(context.metadata),
+        }
+        serialized_context = json.dumps(context_payload, sort_keys=True)
+
+        if prompt_template:
+            return prompt_template.format(context_json=serialized_context)
+
+        return (
+            "Refine this ometeotl generation context and return a JSON object "
+            "containing only context overrides. "
+            f"Context: {serialized_context}"
+        )
+
+    def refine_context(
+        self,
+        context: GenerationContext,
+        *,
+        prompt_template: str | None = None,
+        fallback_to_base: bool = True,
+    ) -> LLMRefinementResult:
+        """Produce a refined GenerationContext from an LLM response.
+
+        When parsing fails and fallback_to_base=True, the original context is
+        returned with diagnostics and used_fallback=True.
+        """
+        prompt = self.render_prompt(context, prompt_template=prompt_template)
+        raw_response = self._text_generator(prompt)
+
+        try:
+            parsed = self._response_parser(raw_response)
+            overrides = self._extract_overrides(parsed)
+            refined = context.copy_with(**overrides)
+            return LLMRefinementResult(
+                refined_context=refined,
+                raw_response=raw_response,
+                used_fallback=False,
+                diagnostics=[],
+            )
+        except Exception as exc:  # noqa: BLE001 - surface robust fallback path
+            if not fallback_to_base:
+                raise
+            return LLMRefinementResult(
+                refined_context=context,
+                raw_response=raw_response,
+                used_fallback=True,
+                diagnostics=[
+                    (
+                        "LLM refinement parsing failed; falling back to base "
+                        f"context: {exc}"
+                    )
+                ],
+            )
+
+    def _extract_overrides(
+        self,
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        allowed_keys = {
+            "label",
+            "attributes",
+            "relations",
+            "state",
+            "context",
+            "provenance",
+            "metadata",
+            "operation",
+            "target_id",
+            "registration_policy",
+            "validate",
+            "validation_mode",
+            "stage_modes",
+        }
+
+        overrides: dict[str, Any] = {}
+        for key in allowed_keys:
+            if key not in payload:
+                continue
+            value = payload[key]
+            if key in {
+                "attributes",
+                "state",
+                "context",
+                "provenance",
+                "metadata",
+                "stage_modes",
+            }:
+                overrides[key] = dict(value or {})
+            elif key == "relations":
+                overrides[key] = {
+                    str(rel_name): [str(item) for item in rel_values or []]
+                    for rel_name, rel_values in dict(value or {}).items()
+                }
+            elif key == "validate":
+                overrides[key] = bool(value)
+            else:
+                overrides[key] = value
+
+        return overrides
+
+    def _parse_json_mapping(self, raw_response: str) -> Mapping[str, Any]:
+        parsed = json.loads(raw_response)
+        if not isinstance(parsed, Mapping):
+            raise ValueError("LLM response must decode to a JSON object")
+        return parsed

--- a/src/ometeotl_core/generation/llm_integration.py
+++ b/src/ometeotl_core/generation/llm_integration.py
@@ -81,6 +81,21 @@ class LLMGenerationAdapter:
         prompt = self.render_prompt(context, prompt_template=prompt_template)
         raw_response = self._text_generator(prompt)
 
+        return self.refine_context_from_response(
+            context,
+            raw_response,
+            fallback_to_base=fallback_to_base,
+        )
+
+    def refine_context_from_response(
+        self,
+        context: GenerationContext,
+        raw_response: str,
+        *,
+        fallback_to_base: bool = True,
+    ) -> LLMRefinementResult:
+        """Refine a context from an already-produced LLM text response."""
+
         try:
             parsed = self._response_parser(raw_response)
             overrides = self._extract_overrides(parsed)

--- a/src/ometeotl_core/generation/pipeline.py
+++ b/src/ometeotl_core/generation/pipeline.py
@@ -242,7 +242,7 @@ class ContextualGenerationPipeline:
         policy = str(context.registration_policy or "none")
         kind = str(context.kind).lower().strip()
 
-        if kind not in {"goal", "strategy", "action"}:
+        if kind not in {"goal", "strategy", "action", "actor", "resource"}:
             return
         if policy == "none":
             return
@@ -338,9 +338,7 @@ class ContextualGenerationPipeline:
         for key, value in dict(context.state).items():
             target.set_state(key, value)
 
-        for key, value in dict(context.context).items():
-            if key:
-                target.context[key] = value
+        self._merge_target_context(target, dict(context.context))
 
         for key, value in dict(context.provenance).items():
             target.set_provenance(key, value)
@@ -360,9 +358,7 @@ class ContextualGenerationPipeline:
         for key, value in dict(context.state).items():
             target.set_state(key, value)
 
-        for key, value in dict(context.context).items():
-            if key:
-                target.context[key] = value
+        self._merge_target_context(target, dict(context.context))
 
         for key, value in dict(context.provenance).items():
             target.set_provenance(key, value)
@@ -372,3 +368,24 @@ class ContextualGenerationPipeline:
                 target.remove_relation(rel_name, existing_target)
             for rel_value in rel_values:
                 target.add_relation(rel_name, rel_value)
+
+    def _merge_target_context(
+        self,
+        target: ModelObject,
+        updates: dict[str, Any],
+    ) -> None:
+        if not updates:
+            return
+
+        merged_context = dict(target.context)
+        has_valid_update = False
+        for key, value in updates.items():
+            if key:
+                merged_context[key] = value
+                has_valid_update = True
+
+        if not has_valid_update:
+            return
+
+        target.context.clear()
+        target.context.update(merged_context)

--- a/src/ometeotl_core/generation/pipeline.py
+++ b/src/ometeotl_core/generation/pipeline.py
@@ -257,6 +257,12 @@ class ContextualGenerationPipeline:
             )
             return
         if not isinstance(generated, ModelObject):
+            if policy == "require":
+                raise TypeError(
+                    "Registration policy 'require' failed: generated object "
+                    f"for kind '{kind}' is not a ModelObject "
+                    f"(got {type(generated).__name__})"
+                )
             diagnostics.append(
                 f"Skipping registration for non-model object generated from kind '{kind}'"
             )

--- a/src/ometeotl_core/generation/pipeline.py
+++ b/src/ometeotl_core/generation/pipeline.py
@@ -18,7 +18,7 @@ from ometeotl_core.validation.pipeline import ValidationPipeline
 from .builders import build_from_context
 from .context import GenerationContext
 from .llm_integration import LLMGenerationAdapter
-from .rules import GenerationRuleSet, default_generation_rules
+from .rule_engine import GenerationRuleSet, combined_generation_rules
 
 VALID_GENERATION_OPERATIONS: frozenset[str] = frozenset(
     {"create", "partial_update", "corrective_update"}
@@ -49,7 +49,7 @@ class ContextualGenerationPipeline:
         rules: GenerationRuleSet | None = None,
         validation_pipeline: ValidationPipeline | None = None,
     ) -> None:
-        self._rules = rules or default_generation_rules()
+        self._rules = rules or combined_generation_rules()
         self._validation_pipeline = validation_pipeline
 
     @property

--- a/src/ometeotl_core/generation/pipeline.py
+++ b/src/ometeotl_core/generation/pipeline.py
@@ -1,0 +1,77 @@
+"""Contextual generation pipeline.
+
+This pipeline starts with deterministic context-to-object generation using explicit
+rules and optional validation. LLM-assisted steps can be layered on top of
+this pipeline later without changing the core API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from ometeotl_core.validation.base import ValidationResult
+from ometeotl_core.validation.pipeline import ValidationPipeline
+
+from .builders import build_from_context
+from .context import GenerationContext
+from .rules import GenerationRuleSet, default_generation_rules
+
+
+@dataclass
+class GenerationResult:
+    """Structured output of one generation request."""
+
+    generated: Any
+    applied_rule_names: list[str] = field(default_factory=list)
+    validation: Optional[ValidationResult] = None
+    diagnostics: list[str] = field(default_factory=list)
+
+
+class ContextualGenerationPipeline:
+    """Deterministic contextual generation with optional validation."""
+
+    def __init__(
+        self,
+        *,
+        rules: GenerationRuleSet | None = None,
+        validation_pipeline: ValidationPipeline | None = None,
+    ) -> None:
+        self._rules = rules or default_generation_rules()
+        self._validation_pipeline = validation_pipeline
+
+    @property
+    def rules(self) -> GenerationRuleSet:
+        return self._rules
+
+    @property
+    def validation_pipeline(self) -> ValidationPipeline | None:
+        return self._validation_pipeline
+
+    def generate(self, context: GenerationContext) -> GenerationResult:
+        """Generate one object from context using rules then builders."""
+        refined_context = self._rules.apply(context)
+        generated = build_from_context(refined_context)
+
+        validation_result: ValidationResult | None = None
+        diagnostics: list[str] = []
+
+        should_validate = bool(refined_context.validate)
+        if should_validate and self._validation_pipeline is not None:
+            validation_result = self._validation_pipeline.validate(
+                generated,
+                mode=refined_context.validation_mode,
+                stage_modes=refined_context.stage_modes,
+                raise_on_error=False,
+            )
+            if not validation_result.valid:
+                diagnostics.append(
+                    "Generated object failed validation; inspect validation summary and issues"
+                )
+
+        return GenerationResult(
+            generated=generated,
+            applied_rule_names=[rule.name for rule in self._rules.rules],
+            validation=validation_result,
+            diagnostics=diagnostics,
+        )

--- a/src/ometeotl_core/generation/pipeline.py
+++ b/src/ometeotl_core/generation/pipeline.py
@@ -36,6 +36,8 @@ class GenerationResult:
     applied_rule_names: list[str] = field(default_factory=list)
     validation: Optional[ValidationResult] = None
     diagnostics: list[str] = field(default_factory=list)
+    uncertainty_zones: list[str] = field(default_factory=list)
+    repair_suggestions: list[str] = field(default_factory=list)
 
 
 class ContextualGenerationPipeline:
@@ -82,13 +84,22 @@ class ContextualGenerationPipeline:
 
         validation_result: ValidationResult | None = None
         diagnostics: list[str] = []
+        repair_suggestions: list[str] = []
 
         if operation == "create":
+            diagnostics.append("stage: instantiation (create)")
             generated = build_from_context(refined_context)
         else:
+            diagnostics.append(f"stage: instantiation ({operation})")
             generated = self._apply_update_operation(
                 refined_context,
                 world=world,
+            )
+
+        uncertainty_zones = self._extract_uncertainty_zones(refined_context)
+        if uncertainty_zones:
+            diagnostics.append(
+                "Explicit uncertainty zones declared: " + ", ".join(uncertainty_zones)
             )
 
         self._apply_registration_policy(
@@ -100,6 +111,7 @@ class ContextualGenerationPipeline:
 
         should_validate = bool(refined_context.validate)
         if should_validate:
+            diagnostics.append("stage: validation")
             if self._validation_pipeline is None:
                 diagnostics.append(
                     "Validation requested but no validation pipeline is configured"
@@ -115,12 +127,48 @@ class ContextualGenerationPipeline:
                     diagnostics.append(
                         "Generated object failed validation; inspect validation summary and issues"
                     )
+                    repair_suggestions = self._build_repair_suggestions(
+                        validation_result
+                    )
+                    diagnostics.extend(
+                        [f"Suggested repair: {item}" for item in repair_suggestions]
+                    )
 
         return GenerationResult(
             generated=generated,
             applied_rule_names=[rule.name for rule in self._rules.rules],
             validation=validation_result,
             diagnostics=diagnostics,
+            uncertainty_zones=uncertainty_zones,
+            repair_suggestions=repair_suggestions,
+        )
+
+    def generate_from_text_response(
+        self,
+        context: GenerationContext,
+        *,
+        raw_response: str,
+        llm_adapter: LLMGenerationAdapter,
+        fallback_to_base: bool = True,
+        world: World | None = None,
+    ) -> GenerationResult:
+        """Run parsing + deterministic generation from an LLM text response."""
+        diagnostics: list[str] = ["stage: parsing"]
+        refinement = llm_adapter.refine_context_from_response(
+            context,
+            raw_response,
+            fallback_to_base=fallback_to_base,
+        )
+        diagnostics.extend(refinement.diagnostics)
+
+        result = self.generate(refinement.refined_context, world=world)
+        return GenerationResult(
+            generated=result.generated,
+            applied_rule_names=result.applied_rule_names,
+            validation=result.validation,
+            diagnostics=diagnostics + list(result.diagnostics),
+            uncertainty_zones=list(result.uncertainty_zones),
+            repair_suggestions=list(result.repair_suggestions),
         )
 
     def generate_hybrid(
@@ -133,18 +181,55 @@ class ContextualGenerationPipeline:
         world: World | None = None,
     ) -> GenerationResult:
         """Run LLM-assisted context refinement before deterministic generation."""
+        diagnostics: list[str] = ["stage: text_generation"]
         refinement = llm_adapter.refine_context(
             context,
             prompt_template=prompt_template,
             fallback_to_base=fallback_to_base,
         )
+        diagnostics.append("stage: parsing")
+        diagnostics.extend(refinement.diagnostics)
+
         result = self.generate(refinement.refined_context, world=world)
         return GenerationResult(
             generated=result.generated,
             applied_rule_names=result.applied_rule_names,
             validation=result.validation,
-            diagnostics=list(refinement.diagnostics) + list(result.diagnostics),
+            diagnostics=diagnostics + list(result.diagnostics),
+            uncertainty_zones=list(result.uncertainty_zones),
+            repair_suggestions=list(result.repair_suggestions),
         )
+
+    def _extract_uncertainty_zones(
+        self,
+        context: GenerationContext,
+    ) -> list[str]:
+        """Extract explicit uncertainty zones from generation context metadata."""
+        raw_zones = context.metadata.get("uncertainty_zones") or context.context.get(
+            "uncertainty_zones"
+        )
+        if not raw_zones:
+            return []
+        if isinstance(raw_zones, str):
+            return [raw_zones]
+        if isinstance(raw_zones, (list, tuple, set)):
+            return [str(item) for item in raw_zones if str(item).strip()]
+        return [str(raw_zones)]
+
+    def _build_repair_suggestions(
+        self,
+        validation_result: ValidationResult,
+    ) -> list[str]:
+        suggestions: list[str] = []
+        for issue in validation_result.errors:
+            candidate = issue.suggestion.strip() if issue.suggestion else ""
+            if candidate:
+                suggestions.append(candidate)
+                continue
+
+            location = issue.path or issue.object_id or "target"
+            suggestions.append(f"Resolve {issue.code} on {location}: {issue.message}")
+        return suggestions
 
     def _apply_registration_policy(
         self,

--- a/src/ometeotl_core/generation/pipeline.py
+++ b/src/ometeotl_core/generation/pipeline.py
@@ -10,12 +10,22 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from ometeotl_core.model.base import ModelObject
+from ometeotl_core.model.world import World
 from ometeotl_core.validation.base import ValidationResult
 from ometeotl_core.validation.pipeline import ValidationPipeline
 
 from .builders import build_from_context
 from .context import GenerationContext
+from .llm_integration import LLMGenerationAdapter
 from .rules import GenerationRuleSet, default_generation_rules
+
+VALID_GENERATION_OPERATIONS: frozenset[str] = frozenset(
+    {"create", "partial_update", "corrective_update"}
+)
+VALID_REGISTRATION_POLICIES: frozenset[str] = frozenset(
+    {"none", "if_available", "require"}
+)
 
 
 @dataclass
@@ -48,26 +58,63 @@ class ContextualGenerationPipeline:
     def validation_pipeline(self) -> ValidationPipeline | None:
         return self._validation_pipeline
 
-    def generate(self, context: GenerationContext) -> GenerationResult:
+    def generate(
+        self,
+        context: GenerationContext,
+        *,
+        world: World | None = None,
+    ) -> GenerationResult:
         """Generate one object from context using rules then builders."""
         refined_context = self._rules.apply(context)
-        generated = build_from_context(refined_context)
+        operation = str(refined_context.operation or "create")
+        if operation not in VALID_GENERATION_OPERATIONS:
+            raise ValueError(
+                "Unsupported generation operation: "
+                f"{operation}. Expected one of {sorted(VALID_GENERATION_OPERATIONS)}"
+            )
+
+        registration_policy = str(refined_context.registration_policy or "none")
+        if registration_policy not in VALID_REGISTRATION_POLICIES:
+            raise ValueError(
+                "Unsupported registration policy: "
+                f"{registration_policy}. Expected one of {sorted(VALID_REGISTRATION_POLICIES)}"
+            )
 
         validation_result: ValidationResult | None = None
         diagnostics: list[str] = []
 
-        should_validate = bool(refined_context.validate)
-        if should_validate and self._validation_pipeline is not None:
-            validation_result = self._validation_pipeline.validate(
-                generated,
-                mode=refined_context.validation_mode,
-                stage_modes=refined_context.stage_modes,
-                raise_on_error=False,
+        if operation == "create":
+            generated = build_from_context(refined_context)
+        else:
+            generated = self._apply_update_operation(
+                refined_context,
+                world=world,
             )
-            if not validation_result.valid:
+
+        self._apply_registration_policy(
+            refined_context,
+            generated,
+            world=world,
+            diagnostics=diagnostics,
+        )
+
+        should_validate = bool(refined_context.validate)
+        if should_validate:
+            if self._validation_pipeline is None:
                 diagnostics.append(
-                    "Generated object failed validation; inspect validation summary and issues"
+                    "Validation requested but no validation pipeline is configured"
                 )
+            else:
+                validation_result = self._validation_pipeline.validate(
+                    generated,
+                    mode=refined_context.validation_mode,
+                    stage_modes=refined_context.stage_modes,
+                    raise_on_error=False,
+                )
+                if not validation_result.valid:
+                    diagnostics.append(
+                        "Generated object failed validation; inspect validation summary and issues"
+                    )
 
         return GenerationResult(
             generated=generated,
@@ -75,3 +122,168 @@ class ContextualGenerationPipeline:
             validation=validation_result,
             diagnostics=diagnostics,
         )
+
+    def generate_hybrid(
+        self,
+        context: GenerationContext,
+        *,
+        llm_adapter: LLMGenerationAdapter,
+        prompt_template: str | None = None,
+        fallback_to_base: bool = True,
+        world: World | None = None,
+    ) -> GenerationResult:
+        """Run LLM-assisted context refinement before deterministic generation."""
+        refinement = llm_adapter.refine_context(
+            context,
+            prompt_template=prompt_template,
+            fallback_to_base=fallback_to_base,
+        )
+        result = self.generate(refinement.refined_context, world=world)
+        return GenerationResult(
+            generated=result.generated,
+            applied_rule_names=result.applied_rule_names,
+            validation=result.validation,
+            diagnostics=list(refinement.diagnostics) + list(result.diagnostics),
+        )
+
+    def _apply_registration_policy(
+        self,
+        context: GenerationContext,
+        generated: Any,
+        *,
+        world: World | None,
+        diagnostics: list[str],
+    ) -> None:
+        policy = str(context.registration_policy or "none")
+        kind = str(context.kind).lower().strip()
+
+        if kind not in {"goal", "strategy", "action"}:
+            return
+        if policy == "none":
+            return
+        if world is None:
+            if policy == "require":
+                raise ValueError(
+                    "Registration policy 'require' needs a world context for "
+                    f"generated {kind} '{context.id}'"
+                )
+            diagnostics.append(
+                f"Skipped registration for {kind} '{context.id}': no world context provided"
+            )
+            return
+        if not isinstance(generated, ModelObject):
+            diagnostics.append(
+                f"Skipping registration for non-model object generated from kind '{kind}'"
+            )
+            return
+
+        existing = world.model_registry.get(generated.id)
+        if existing is not None:
+            diagnostics.append(
+                f"Registration skipped for '{generated.id}': object already present in world registry"
+            )
+            return
+
+        world.register_object(generated)
+        diagnostics.append(
+            f"Registered generated {kind} '{generated.id}' in world '{world.id}'"
+        )
+
+    def _apply_update_operation(
+        self,
+        context: GenerationContext,
+        *,
+        world: World | None,
+    ) -> ModelObject:
+        if world is None:
+            raise ValueError(
+                f"Operation '{context.operation}' requires a world context"
+            )
+
+        target = self._resolve_update_target(context, world)
+        operation = str(context.operation)
+
+        if operation == "partial_update":
+            self._apply_partial_update(target, context)
+            return target
+        if operation == "corrective_update":
+            self._apply_corrective_update(target, context)
+            return target
+
+        raise ValueError(f"Unsupported update operation: {operation}")
+
+    def _resolve_update_target(
+        self,
+        context: GenerationContext,
+        world: World,
+    ) -> ModelObject:
+        target_id = str(context.target_id or context.id)
+        kind = str(context.kind).lower().strip()
+
+        if kind == "world" and target_id == world.id:
+            return world
+
+        if kind == "space":
+            space = world.get_space(target_id)
+            if space is not None:
+                return space
+
+        target = world.model_registry.get(target_id)
+        if target is None:
+            raise ValueError(
+                f"Unable to apply {context.operation}: target '{target_id}' does not exist"
+            )
+
+        if str(target.object_type).lower() != kind:
+            raise ValueError(
+                "Target object type mismatch for update operation: "
+                f"expected '{kind}', found '{target.object_type}'"
+            )
+
+        return target
+
+    def _apply_partial_update(
+        self,
+        target: ModelObject,
+        context: GenerationContext,
+    ) -> None:
+        for key, value in context.merged_attributes().items():
+            target.set_attribute(key, value)
+
+        for key, value in dict(context.state).items():
+            target.set_state(key, value)
+
+        for key, value in dict(context.context).items():
+            if key:
+                target.context[key] = value
+
+        for key, value in dict(context.provenance).items():
+            target.set_provenance(key, value)
+
+        for rel_name, rel_values in context.normalized_relations().items():
+            for rel_value in rel_values:
+                target.add_relation(rel_name, rel_value)
+
+    def _apply_corrective_update(
+        self,
+        target: ModelObject,
+        context: GenerationContext,
+    ) -> None:
+        for key, value in context.merged_attributes().items():
+            target.set_attribute(key, value)
+
+        for key, value in dict(context.state).items():
+            target.set_state(key, value)
+
+        for key, value in dict(context.context).items():
+            if key:
+                target.context[key] = value
+
+        for key, value in dict(context.provenance).items():
+            target.set_provenance(key, value)
+
+        for rel_name, rel_values in context.normalized_relations().items():
+            for existing_target in list(target.relations.get(rel_name, [])):
+                target.remove_relation(rel_name, existing_target)
+            for rel_value in rel_values:
+                target.add_relation(rel_name, rel_value)

--- a/src/ometeotl_core/generation/pipeline.py
+++ b/src/ometeotl_core/generation/pipeline.py
@@ -380,7 +380,7 @@ class ContextualGenerationPipeline:
         merged_context = dict(target.context)
         has_valid_update = False
         for key, value in updates.items():
-            if key:
+            if key is not None and (not isinstance(key, str) or key.strip()):
                 merged_context[key] = value
                 has_valid_update = True
 

--- a/src/ometeotl_core/generation/rule_engine.py
+++ b/src/ometeotl_core/generation/rule_engine.py
@@ -1,0 +1,248 @@
+"""Pluggable rule engine for contextual generation.
+
+Provides a dedicated registry and constraint propagation rules
+(temporal, spatial, admissibility).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
+
+from .context import GenerationContext
+
+GenerationRulePredicate = Callable[[GenerationContext], bool]
+GenerationRuleApply = Callable[[GenerationContext], GenerationContext]
+
+
+@dataclass(frozen=True)
+class GenerationRule:
+    """One deterministic transformation rule for generation contexts."""
+
+    name: str
+    predicate: GenerationRulePredicate
+    apply: GenerationRuleApply
+
+    def run(self, context: GenerationContext) -> GenerationContext:
+        if self.predicate(context):
+            return self.apply(context)
+        return context
+
+
+class GenerationRuleSet:
+    """Ordered set of generation rules."""
+
+    def __init__(self, rules: Iterable[GenerationRule] | None = None) -> None:
+        self._rules = list(rules or [])
+
+    @property
+    def rules(self) -> list[GenerationRule]:
+        return list(self._rules)
+
+    def apply(self, context: GenerationContext) -> GenerationContext:
+        updated = context
+        for rule in self._rules:
+            updated = rule.run(updated)
+        return updated
+
+
+class RuleRegistry:
+    """Registry of named rule sets for pluggable generation policies."""
+
+    def __init__(self) -> None:
+        self._rule_sets: dict[str, GenerationRuleSet] = {}
+
+    def register(self, name: str, rule_set: GenerationRuleSet) -> None:
+        normalized = str(name).strip()
+        if not normalized:
+            raise ValueError("RuleRegistry name cannot be empty")
+        self._rule_sets[normalized] = rule_set
+
+    def exists(self, name: str) -> bool:
+        return str(name).strip() in self._rule_sets
+
+    def get(self, name: str) -> GenerationRuleSet | None:
+        return self._rule_sets.get(str(name).strip())
+
+    def require(self, name: str) -> GenerationRuleSet:
+        result = self.get(name)
+        if result is None:
+            raise KeyError(f"Unknown generation rule set: {name}")
+        return result
+
+    def names(self) -> list[str]:
+        return sorted(self._rule_sets.keys())
+
+
+def _normalize_relation_lists(context: GenerationContext) -> GenerationContext:
+    return context.copy_with(relations=context.normalized_relations())
+
+
+def _promote_label_to_attributes(context: GenerationContext) -> GenerationContext:
+    return context.copy_with(attributes=context.merged_attributes())
+
+
+def _coerce_positive_int(value: Any, fallback: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    return parsed if parsed > 0 else fallback
+
+
+def _coerce_non_negative_int(value: Any, fallback: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    return parsed if parsed >= 0 else fallback
+
+
+def _propagate_temporal_constraints(context: GenerationContext) -> GenerationContext:
+    constraints = dict(context.constraints)
+    temporal = dict(constraints.get("temporal") or {})
+    metadata = dict(context.metadata)
+
+    window = temporal.get("window")
+    if window is not None:
+        metadata.setdefault("horizon", {})
+        horizon = dict(metadata["horizon"])
+        horizon.setdefault("window", _coerce_positive_int(window, 1))
+        metadata["horizon"] = horizon
+
+    start = temporal.get("start_step")
+    if start is not None:
+        metadata.setdefault("timeline", {})
+        timeline = dict(metadata["timeline"])
+        timeline.setdefault("start_step", _coerce_non_negative_int(start, 0))
+        metadata["timeline"] = timeline
+
+    return context.copy_with(metadata=metadata)
+
+
+def _propagate_spatial_constraints(context: GenerationContext) -> GenerationContext:
+    constraints = dict(context.constraints)
+    spatial = dict(constraints.get("spatial") or {})
+    metadata = dict(context.metadata)
+
+    allowed_spaces = spatial.get("allowed_spaces")
+    if allowed_spaces:
+        normalized_spaces = [
+            str(space_id) for space_id in allowed_spaces if str(space_id).strip()
+        ]
+        if normalized_spaces:
+            metadata.setdefault("allowed_spaces", sorted(set(normalized_spaces)))
+
+    required_space = spatial.get("required_space")
+    if required_space:
+        metadata.setdefault("space_id", str(required_space))
+
+    return context.copy_with(metadata=metadata)
+
+
+def _propagate_admissibility_constraints(
+    context: GenerationContext,
+) -> GenerationContext:
+    constraints = dict(context.constraints)
+    admissibility = dict(constraints.get("admissibility") or {})
+    metadata = dict(context.metadata)
+
+    capability = admissibility.get("required_capability")
+    if capability:
+        metadata.setdefault("required_capability", str(capability))
+
+    threshold = admissibility.get("minimum_confidence")
+    if threshold is not None:
+        try:
+            normalized_threshold = float(threshold)
+        except (TypeError, ValueError):
+            normalized_threshold = 0.0
+        metadata.setdefault(
+            "minimum_confidence", max(0.0, min(1.0, normalized_threshold))
+        )
+
+    return context.copy_with(metadata=metadata)
+
+
+def default_generation_rules() -> GenerationRuleSet:
+    """Return the default deterministic rule set for generation."""
+    return GenerationRuleSet(
+        [
+            GenerationRule(
+                name="normalize_relations",
+                predicate=lambda context: bool(context.relations),
+                apply=_normalize_relation_lists,
+            ),
+            GenerationRule(
+                name="promote_label",
+                predicate=lambda context: bool(context.label),
+                apply=_promote_label_to_attributes,
+            ),
+        ]
+    )
+
+
+def temporal_constraint_rules() -> GenerationRuleSet:
+    """Rule set focused on temporal constraint propagation."""
+    return GenerationRuleSet(
+        [
+            GenerationRule(
+                name="propagate_temporal_constraints",
+                predicate=lambda context: bool(
+                    dict(context.constraints).get("temporal")
+                ),
+                apply=_propagate_temporal_constraints,
+            )
+        ]
+    )
+
+
+def spatial_constraint_rules() -> GenerationRuleSet:
+    """Rule set focused on spatial constraint propagation."""
+    return GenerationRuleSet(
+        [
+            GenerationRule(
+                name="propagate_spatial_constraints",
+                predicate=lambda context: bool(
+                    dict(context.constraints).get("spatial")
+                ),
+                apply=_propagate_spatial_constraints,
+            )
+        ]
+    )
+
+
+def admissibility_constraint_rules() -> GenerationRuleSet:
+    """Rule set focused on admissibility constraint propagation."""
+    return GenerationRuleSet(
+        [
+            GenerationRule(
+                name="propagate_admissibility_constraints",
+                predicate=lambda context: bool(
+                    dict(context.constraints).get("admissibility")
+                ),
+                apply=_propagate_admissibility_constraints,
+            )
+        ]
+    )
+
+
+def combined_generation_rules() -> GenerationRuleSet:
+    """Return a combined default rule set including constraint propagation."""
+    combined_rules: list[GenerationRule] = []
+    combined_rules.extend(default_generation_rules().rules)
+    combined_rules.extend(temporal_constraint_rules().rules)
+    combined_rules.extend(spatial_constraint_rules().rules)
+    combined_rules.extend(admissibility_constraint_rules().rules)
+    return GenerationRuleSet(combined_rules)
+
+
+def default_rule_registry() -> RuleRegistry:
+    """Return registry pre-populated with built-in generation rule sets."""
+    registry = RuleRegistry()
+    registry.register("default", default_generation_rules())
+    registry.register("temporal", temporal_constraint_rules())
+    registry.register("spatial", spatial_constraint_rules())
+    registry.register("admissibility", admissibility_constraint_rules())
+    registry.register("combined", combined_generation_rules())
+    return registry

--- a/src/ometeotl_core/generation/rule_engine.py
+++ b/src/ometeotl_core/generation/rule_engine.py
@@ -127,9 +127,14 @@ def _propagate_spatial_constraints(context: GenerationContext) -> GenerationCont
 
     allowed_spaces = spatial.get("allowed_spaces")
     if allowed_spaces:
-        normalized_spaces = [
-            str(space_id) for space_id in allowed_spaces if str(space_id).strip()
-        ]
+        if isinstance(allowed_spaces, str):
+            allowed_spaces = [allowed_spaces]
+        try:
+            normalized_spaces = [
+                str(space_id) for space_id in allowed_spaces if str(space_id).strip()
+            ]
+        except TypeError:
+            normalized_spaces = []
         if normalized_spaces:
             metadata.setdefault("allowed_spaces", sorted(set(normalized_spaces)))
 

--- a/src/ometeotl_core/generation/rules.py
+++ b/src/ometeotl_core/generation/rules.py
@@ -1,0 +1,73 @@
+"""Minimal rule engine for contextual generation.
+
+Rules are intentionally simple callables over ``GenerationContext`` so the
+pipeline can perform deterministic pre-build adjustments without introducing a
+new policy subsystem.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from .context import GenerationContext
+
+GenerationRulePredicate = Callable[[GenerationContext], bool]
+GenerationRuleApply = Callable[[GenerationContext], GenerationContext]
+
+
+@dataclass(frozen=True)
+class GenerationRule:
+    """One deterministic transformation rule for generation contexts."""
+
+    name: str
+    predicate: GenerationRulePredicate
+    apply: GenerationRuleApply
+
+    def run(self, context: GenerationContext) -> GenerationContext:
+        if self.predicate(context):
+            return self.apply(context)
+        return context
+
+
+class GenerationRuleSet:
+    """Ordered set of generation rules."""
+
+    def __init__(self, rules: Iterable[GenerationRule] | None = None) -> None:
+        self._rules = list(rules or [])
+
+    @property
+    def rules(self) -> list[GenerationRule]:
+        return list(self._rules)
+
+    def apply(self, context: GenerationContext) -> GenerationContext:
+        updated = context
+        for rule in self._rules:
+            updated = rule.run(updated)
+        return updated
+
+
+def _normalize_relation_lists(context: GenerationContext) -> GenerationContext:
+    return context.copy_with(relations=context.normalized_relations())
+
+
+def _promote_label_to_attributes(context: GenerationContext) -> GenerationContext:
+    return context.copy_with(attributes=context.merged_attributes())
+
+
+def default_generation_rules() -> GenerationRuleSet:
+    """Return the default deterministic rule set for generation."""
+    return GenerationRuleSet(
+        [
+            GenerationRule(
+                name="normalize_relations",
+                predicate=lambda context: bool(context.relations),
+                apply=_normalize_relation_lists,
+            ),
+            GenerationRule(
+                name="promote_label",
+                predicate=lambda context: bool(context.label),
+                apply=_promote_label_to_attributes,
+            ),
+        ]
+    )

--- a/src/ometeotl_core/generation/rules.py
+++ b/src/ometeotl_core/generation/rules.py
@@ -1,73 +1,29 @@
-"""Minimal rule engine for contextual generation.
+"""Compatibility exports for generation rule APIs.
 
-Rules are intentionally simple callables over ``GenerationContext`` so the
-pipeline can perform deterministic pre-build adjustments without introducing a
-new policy subsystem.
+New code should import from .rule_engine; this module is kept to avoid
+breaking existing imports.
 """
 
-from __future__ import annotations
+from .rule_engine import (  # noqa: F401
+    GenerationRule,
+    GenerationRuleSet,
+    RuleRegistry,
+    admissibility_constraint_rules,
+    combined_generation_rules,
+    default_generation_rules,
+    default_rule_registry,
+    spatial_constraint_rules,
+    temporal_constraint_rules,
+)
 
-from dataclasses import dataclass
-from typing import Callable, Iterable
-
-from .context import GenerationContext
-
-GenerationRulePredicate = Callable[[GenerationContext], bool]
-GenerationRuleApply = Callable[[GenerationContext], GenerationContext]
-
-
-@dataclass(frozen=True)
-class GenerationRule:
-    """One deterministic transformation rule for generation contexts."""
-
-    name: str
-    predicate: GenerationRulePredicate
-    apply: GenerationRuleApply
-
-    def run(self, context: GenerationContext) -> GenerationContext:
-        if self.predicate(context):
-            return self.apply(context)
-        return context
-
-
-class GenerationRuleSet:
-    """Ordered set of generation rules."""
-
-    def __init__(self, rules: Iterable[GenerationRule] | None = None) -> None:
-        self._rules = list(rules or [])
-
-    @property
-    def rules(self) -> list[GenerationRule]:
-        return list(self._rules)
-
-    def apply(self, context: GenerationContext) -> GenerationContext:
-        updated = context
-        for rule in self._rules:
-            updated = rule.run(updated)
-        return updated
-
-
-def _normalize_relation_lists(context: GenerationContext) -> GenerationContext:
-    return context.copy_with(relations=context.normalized_relations())
-
-
-def _promote_label_to_attributes(context: GenerationContext) -> GenerationContext:
-    return context.copy_with(attributes=context.merged_attributes())
-
-
-def default_generation_rules() -> GenerationRuleSet:
-    """Return the default deterministic rule set for generation."""
-    return GenerationRuleSet(
-        [
-            GenerationRule(
-                name="normalize_relations",
-                predicate=lambda context: bool(context.relations),
-                apply=_normalize_relation_lists,
-            ),
-            GenerationRule(
-                name="promote_label",
-                predicate=lambda context: bool(context.label),
-                apply=_promote_label_to_attributes,
-            ),
-        ]
-    )
+__all__ = [
+    "GenerationRule",
+    "GenerationRuleSet",
+    "RuleRegistry",
+    "default_generation_rules",
+    "temporal_constraint_rules",
+    "spatial_constraint_rules",
+    "admissibility_constraint_rules",
+    "combined_generation_rules",
+    "default_rule_registry",
+]

--- a/src/ometeotl_core/model/actors.py
+++ b/src/ometeotl_core/model/actors.py
@@ -256,7 +256,7 @@ class Actor(GenericObject):
             context=dict(payload.get("context") or {}),
             provenance=dict(payload.get("provenance") or {}),
             metadata=dict(payload.get("metadata") or {}),
-            validate=True,
+            validate=bool(payload.get("validate", True)),
             validation_mode=str(payload.get("validation_mode") or "strict"),
             stage_modes=dict(payload.get("stage_modes") or {}),
         )

--- a/src/ometeotl_core/model/actors.py
+++ b/src/ometeotl_core/model/actors.py
@@ -81,9 +81,7 @@ class Actor(GenericObject):
         self.attributes.setdefault("roles", [])
         self.attributes.setdefault("profile", {})
         self.attributes.setdefault("emergent", False)
-        self.attributes.setdefault(
-            "composition_mode", "standalone"
-        )
+        self.attributes.setdefault("composition_mode", "standalone")
 
     @property
     def kind(self) -> str:
@@ -153,17 +151,13 @@ class Actor(GenericObject):
           clear existence but is treated as an actor for modeling purposes or
           through other actors interactions.
         """
-        value = self.attributes.get(
-            "composition_mode", "standalone"
-        )
+        value = self.attributes.get("composition_mode", "standalone")
         return str(value) if value is not None else "standalone"
 
     @composition_mode.setter
     def composition_mode(self, value: str) -> None:
         """Sets the actor's composition mode."""
-        _require_non_empty(
-            value, "Composition mode cannot be empty"
-        )
+        _require_non_empty(value, "Composition mode cannot be empty")
         self.attributes["composition_mode"] = value
 
     @property
@@ -229,9 +223,55 @@ class Actor(GenericObject):
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "Actor":
         """Create an Actor instance from a dictionary representation."""
-        return cls(
-            **_base_kwargs_from_typed_payload(data, "actor")
+        return cls(**_base_kwargs_from_typed_payload(data, "actor"))
+
+    @classmethod
+    def from_context(cls, context: Mapping[str, Any]) -> "Actor":
+        """Build an actor from contextual payload via generation pipeline."""
+        from ometeotl_core.generation import (
+            ContextualGenerationPipeline,
+            GenerationContext,
         )
+        from ometeotl_core.validation import (
+            StructuralValidator,
+            ValidationException,
+            ValidationPipeline,
+        )
+
+        payload = dict(context)
+        actor_id = str(payload.get("id") or "")
+        if not actor_id:
+            raise ValueError("Actor.from_context requires non-empty 'id'")
+
+        generation_context = GenerationContext(
+            kind="actor",
+            id=actor_id,
+            label=str(payload.get("label") or ""),
+            attributes=dict(payload.get("attributes") or {}),
+            relations={
+                str(name): [str(item) for item in values or []]
+                for name, values in dict(payload.get("relations") or {}).items()
+            },
+            state=dict(payload.get("state") or {}),
+            context=dict(payload.get("context") or {}),
+            provenance=dict(payload.get("provenance") or {}),
+            metadata=dict(payload.get("metadata") or {}),
+            validate=True,
+            validation_mode=str(payload.get("validation_mode") or "strict"),
+            stage_modes=dict(payload.get("stage_modes") or {}),
+        )
+
+        pipeline = ContextualGenerationPipeline(
+            validation_pipeline=ValidationPipeline(validators=[StructuralValidator()])
+        )
+        result = pipeline.generate(generation_context)
+        if result.validation is not None and not result.validation.valid:
+            raise ValidationException(result.validation)
+        if not isinstance(result.generated, cls):
+            raise TypeError(
+                f"Actor.from_context expected generated Actor, got {type(result.generated).__name__}"
+            )
+        return result.generated
 
 
 # ---------------------------------------------------------------------------
@@ -363,9 +403,7 @@ def is_abstract_composite(
     if not actor.is_composite:
         return False
 
-    spaces = world.space_object_graph.spaces_where_object_exists(
-        actor.id
-    )
+    spaces = world.space_object_graph.spaces_where_object_exists(actor.id)
     if not spaces:
         return False
     return all(space.is_abstract for space in spaces)

--- a/src/ometeotl_core/model/goals.py
+++ b/src/ometeotl_core/model/goals.py
@@ -173,6 +173,66 @@ class Goal(ModelObject):
             strategy_ids=[str(sid) for sid in (data.get("strategy_ids") or [])],
         )
 
+    @classmethod
+    def from_context(cls, context: Mapping[str, Any]) -> "Goal":
+        """Build a goal from contextual payload via generation pipeline."""
+        from ometeotl_core.generation import (
+            ContextualGenerationPipeline,
+            GenerationContext,
+        )
+        from ometeotl_core.validation import (
+            StructuralValidator,
+            ValidationException,
+            ValidationPipeline,
+        )
+
+        payload = dict(context)
+        goal_id = str(payload.get("id") or "")
+        if not goal_id:
+            raise ValueError("Goal.from_context requires non-empty 'id'")
+
+        metadata = dict(payload.get("metadata") or {})
+        for key in (
+            "actor_id",
+            "kind",
+            "priority",
+            "status",
+            "horizon",
+            "target_condition",
+        ):
+            if key in payload and key not in metadata:
+                metadata[key] = payload[key]
+
+        generation_context = GenerationContext(
+            kind="goal",
+            id=goal_id,
+            label=str(payload.get("label") or ""),
+            attributes=dict(payload.get("attributes") or {}),
+            relations={
+                str(name): [str(item) for item in values or []]
+                for name, values in dict(payload.get("relations") or {}).items()
+            },
+            state=dict(payload.get("state") or {}),
+            context=dict(payload.get("context") or {}),
+            provenance=dict(payload.get("provenance") or {}),
+            metadata=metadata,
+            validate=True,
+            validation_mode=str(payload.get("validation_mode") or "strict"),
+            stage_modes=dict(payload.get("stage_modes") or {}),
+        )
+
+        pipeline = ContextualGenerationPipeline(
+            validation_pipeline=ValidationPipeline(validators=[StructuralValidator()])
+        )
+        result = pipeline.generate(generation_context)
+        if result.validation is not None and not result.validation.valid:
+            raise ValidationException(result.validation)
+        if not isinstance(result.generated, cls):
+            raise TypeError(
+                f"Goal.from_context expected generated Goal, got {type(result.generated).__name__}"
+            )
+        return result.generated
+
 
 @dataclass
 class GoalDecompositionTree:

--- a/src/ometeotl_core/model/goals.py
+++ b/src/ometeotl_core/model/goals.py
@@ -216,7 +216,7 @@ class Goal(ModelObject):
             context=dict(payload.get("context") or {}),
             provenance=dict(payload.get("provenance") or {}),
             metadata=metadata,
-            validate=True,
+            validate=bool(payload.get("validate", True)),
             validation_mode=str(payload.get("validation_mode") or "strict"),
             stage_modes=dict(payload.get("stage_modes") or {}),
         )

--- a/src/ometeotl_core/model/strategies.py
+++ b/src/ometeotl_core/model/strategies.py
@@ -331,6 +331,66 @@ class Strategy(ModelObject):
             ),
         )
 
+    @classmethod
+    def from_context(cls, context: Mapping[str, Any]) -> "Strategy":
+        """Build a strategy from contextual payload via generation pipeline."""
+        from ometeotl_core.generation import (
+            ContextualGenerationPipeline,
+            GenerationContext,
+        )
+        from ometeotl_core.validation import (
+            StructuralValidator,
+            ValidationException,
+            ValidationPipeline,
+        )
+
+        payload = dict(context)
+        strategy_id = str(payload.get("id") or "")
+        if not strategy_id:
+            raise ValueError("Strategy.from_context requires non-empty 'id'")
+
+        metadata = dict(payload.get("metadata") or {})
+        for key in (
+            "actor_id",
+            "goal_id",
+            "root_node_id",
+            "action_id",
+            "projection_policy",
+        ):
+            if key in payload and key not in metadata:
+                metadata[key] = payload[key]
+
+        generation_context = GenerationContext(
+            kind="strategy",
+            id=strategy_id,
+            label=str(payload.get("label") or ""),
+            attributes=dict(payload.get("attributes") or {}),
+            relations={
+                str(name): [str(item) for item in values or []]
+                for name, values in dict(payload.get("relations") or {}).items()
+            },
+            state=dict(payload.get("state") or {}),
+            context=dict(payload.get("context") or {}),
+            provenance=dict(payload.get("provenance") or {}),
+            metadata=metadata,
+            validate=True,
+            validation_mode=str(payload.get("validation_mode") or "strict"),
+            stage_modes=dict(payload.get("stage_modes") or {}),
+        )
+
+        pipeline = ContextualGenerationPipeline(
+            validation_pipeline=ValidationPipeline(validators=[StructuralValidator()])
+        )
+        result = pipeline.generate(generation_context)
+        if result.validation is not None and not result.validation.valid:
+            raise ValidationException(result.validation)
+        if not isinstance(result.generated, cls):
+            raise TypeError(
+                "Strategy.from_context expected generated Strategy, got "
+                f"{type(result.generated).__name__}"
+            )
+        return result.generated
+
 
 def _default_strategy_node_id(index: int, action: Action) -> ObjectId:
     return f"node-{index:04d}-{action.id}"

--- a/src/ometeotl_core/model/strategies.py
+++ b/src/ometeotl_core/model/strategies.py
@@ -373,7 +373,7 @@ class Strategy(ModelObject):
             context=dict(payload.get("context") or {}),
             provenance=dict(payload.get("provenance") or {}),
             metadata=metadata,
-            validate=True,
+            validate=bool(payload.get("validate", True)),
             validation_mode=str(payload.get("validation_mode") or "strict"),
             stage_modes=dict(payload.get("stage_modes") or {}),
         )

--- a/src/ometeotl_core/model/world.py
+++ b/src/ometeotl_core/model/world.py
@@ -296,10 +296,16 @@ class World(Space):
             if not isinstance(entry, Mapping):
                 raise TypeError("World.from_context expected mapping for 'placements'")
             placement_payload = dict(entry)
+            object_id = str(placement_payload.get("object_id") or "").strip()
+            space_id = str(placement_payload.get("space_id") or "").strip()
+            if not object_id or not space_id:
+                raise ValueError(
+                    "World.from_context placements require non-empty 'object_id' and 'space_id'"
+                )
             placements.append(
                 GenerationPlacement(
-                    object_id=str(placement_payload.get("object_id") or ""),
-                    space_id=str(placement_payload.get("space_id") or ""),
+                    object_id=object_id,
+                    space_id=space_id,
                     role=str(placement_payload.get("role") or "occupies"),
                     metadata=dict(placement_payload.get("metadata") or {}),
                 )

--- a/src/ometeotl_core/model/world.py
+++ b/src/ometeotl_core/model/world.py
@@ -227,3 +227,114 @@ class World(Space):
                 data.get("model_registry") or {}
             ),
         )
+
+    @classmethod
+    def from_context(cls, context: Mapping[str, Any]) -> "World":
+        """Build a world from contextual payload via generation pipeline."""
+        from ometeotl_core.generation import (
+            ContextualGenerationPipeline,
+            GenerationContext,
+            GenerationPlacement,
+        )
+        from ometeotl_core.validation import (
+            StructuralValidator,
+            ValidationException,
+            ValidationPipeline,
+        )
+
+        payload = dict(context)
+        world_id = str(payload.get("id") or "")
+        if not world_id:
+            raise ValueError("World.from_context requires non-empty 'id'")
+
+        def _parse_contexts(raw_contexts: Any, kind: str) -> list[GenerationContext]:
+            parsed: list[GenerationContext] = []
+            for entry in raw_contexts or []:
+                if isinstance(entry, GenerationContext):
+                    parsed.append(entry)
+                    continue
+                if not isinstance(entry, Mapping):
+                    raise TypeError(
+                        f"World.from_context expected mapping for nested '{kind}' context"
+                    )
+                nested_payload = dict(entry)
+                nested_id = str(nested_payload.get("id") or "")
+                if not nested_id:
+                    raise ValueError(
+                        f"World.from_context requires non-empty nested '{kind}' id"
+                    )
+                parsed.append(
+                    GenerationContext(
+                        kind=str(nested_payload.get("kind") or kind),
+                        id=nested_id,
+                        label=str(nested_payload.get("label") or ""),
+                        attributes=dict(nested_payload.get("attributes") or {}),
+                        relations={
+                            str(name): [str(item) for item in values or []]
+                            for name, values in dict(
+                                nested_payload.get("relations") or {}
+                            ).items()
+                        },
+                        state=dict(nested_payload.get("state") or {}),
+                        context=dict(nested_payload.get("context") or {}),
+                        provenance=dict(nested_payload.get("provenance") or {}),
+                        metadata=dict(nested_payload.get("metadata") or {}),
+                        validate=bool(nested_payload.get("validate", True)),
+                        validation_mode=str(
+                            nested_payload.get("validation_mode") or "strict"
+                        ),
+                        stage_modes=dict(nested_payload.get("stage_modes") or {}),
+                    )
+                )
+            return parsed
+
+        placements: list[GenerationPlacement] = []
+        for entry in payload.get("placements") or []:
+            if isinstance(entry, GenerationPlacement):
+                placements.append(entry)
+                continue
+            if not isinstance(entry, Mapping):
+                raise TypeError("World.from_context expected mapping for 'placements'")
+            placement_payload = dict(entry)
+            placements.append(
+                GenerationPlacement(
+                    object_id=str(placement_payload.get("object_id") or ""),
+                    space_id=str(placement_payload.get("space_id") or ""),
+                    role=str(placement_payload.get("role") or "occupies"),
+                    metadata=dict(placement_payload.get("metadata") or {}),
+                )
+            )
+
+        generation_context = GenerationContext(
+            kind="world",
+            id=world_id,
+            label=str(payload.get("label") or ""),
+            attributes=dict(payload.get("attributes") or {}),
+            relations={
+                str(name): [str(item) for item in values or []]
+                for name, values in dict(payload.get("relations") or {}).items()
+            },
+            state=dict(payload.get("state") or {}),
+            context=dict(payload.get("context") or {}),
+            provenance=dict(payload.get("provenance") or {}),
+            metadata=dict(payload.get("metadata") or {}),
+            spaces=_parse_contexts(payload.get("spaces"), "space"),
+            actors=_parse_contexts(payload.get("actors"), "actor"),
+            resources=_parse_contexts(payload.get("resources"), "resource"),
+            placements=placements,
+            validate=True,
+            validation_mode=str(payload.get("validation_mode") or "strict"),
+            stage_modes=dict(payload.get("stage_modes") or {}),
+        )
+
+        pipeline = ContextualGenerationPipeline(
+            validation_pipeline=ValidationPipeline(validators=[StructuralValidator()])
+        )
+        result = pipeline.generate(generation_context)
+        if result.validation is not None and not result.validation.valid:
+            raise ValidationException(result.validation)
+        if not isinstance(result.generated, cls):
+            raise TypeError(
+                f"World.from_context expected generated World, got {type(result.generated).__name__}"
+            )
+        return result.generated

--- a/src/ometeotl_core/model/world.py
+++ b/src/ometeotl_core/model/world.py
@@ -322,7 +322,7 @@ class World(Space):
             actors=_parse_contexts(payload.get("actors"), "actor"),
             resources=_parse_contexts(payload.get("resources"), "resource"),
             placements=placements,
-            validate=True,
+            validate=bool(payload.get("validate", True)),
             validation_mode=str(payload.get("validation_mode") or "strict"),
             stage_modes=dict(payload.get("stage_modes") or {}),
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,162 @@
+"""Global pytest hooks for export audit artifact capture.
+
+This test hook records serialization/export outputs so they can be audited under
+local_lab/artifacts without changing each test individually.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import inspect
+import pkgutil
+import re
+from collections import defaultdict
+from typing import Any, Callable
+
+import pytest
+
+from tests.ometeotl_core._artifact_utils import (
+    write_json_artifact,
+    write_text_artifact,
+)
+
+_CURRENT_TEST_NODEID = ""
+_LAYER_COUNTERS: defaultdict[str, int] = defaultdict(int)
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_-]+", "_", value).strip("_").lower()
+
+
+def _safe_write_json(*, layer: str, name: str, payload: Any) -> None:
+    try:
+        write_json_artifact(layer=layer, name=name, payload=payload)
+    except Exception as exc:  # pragma: no cover - never break tests on audit write
+        write_json_artifact(
+            layer=layer,
+            name=f"{name}_fallback",
+            payload={
+                "error": str(exc),
+                "payload_repr": repr(payload),
+            },
+        )
+
+
+def _record_json_artifact(*, layer: str, label: str, payload: Any) -> None:
+    if not _CURRENT_TEST_NODEID:
+        return
+    _LAYER_COUNTERS[layer] += 1
+    counter = _LAYER_COUNTERS[layer]
+    name = f"{_slug(_CURRENT_TEST_NODEID)}__{_slug(label)}__{counter:03d}"
+    _safe_write_json(layer=layer, name=name, payload=payload)
+
+
+def _record_text_artifact(*, layer: str, label: str, content: str, extension: str) -> None:
+    if not _CURRENT_TEST_NODEID:
+        return
+    _LAYER_COUNTERS[layer] += 1
+    counter = _LAYER_COUNTERS[layer]
+    name = f"{_slug(_CURRENT_TEST_NODEID)}__{_slug(label)}__{counter:03d}"
+    try:
+        write_text_artifact(
+            layer=layer,
+            name=name,
+            content=content,
+            extension=extension,
+        )
+    except Exception:
+        # Artifact writes must stay observational and never impact test behavior.
+        pass
+
+
+def _wrap_method(cls: type[Any], method_name: str, layer: str) -> None:
+    method = getattr(cls, method_name, None)
+    if method is None or not callable(method):
+        return
+    if getattr(method, "__ometeotl_audit_wrapped__", False):
+        return
+
+    @functools.wraps(method)
+    def wrapped(self: Any, *args: Any, **kwargs: Any) -> Any:
+        result = method(self, *args, **kwargs)
+        _record_json_artifact(
+            layer=layer,
+            label=f"{cls.__name__}_{method_name}",
+            payload=result,
+        )
+        return result
+
+    setattr(wrapped, "__ometeotl_audit_wrapped__", True)
+    setattr(cls, method_name, wrapped)
+
+
+def _wrap_function(module: Any, function_name: str, layer: str, extension: str) -> None:
+    function = getattr(module, function_name, None)
+    if function is None or not callable(function):
+        return
+    if getattr(function, "__ometeotl_audit_wrapped__", False):
+        return
+
+    @functools.wraps(function)
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        result = function(*args, **kwargs)
+        if extension == "json":
+            _record_text_artifact(
+                layer=layer,
+                label=function_name,
+                content=str(result),
+                extension="json",
+            )
+        elif extension == "yaml":
+            _record_text_artifact(
+                layer=layer,
+                label=function_name,
+                content=str(result),
+                extension="yaml",
+            )
+        else:
+            _record_json_artifact(
+                layer=layer,
+                label=function_name,
+                payload=result,
+            )
+        return result
+
+    setattr(wrapped, "__ometeotl_audit_wrapped__", True)
+    setattr(module, function_name, wrapped)
+
+
+def _install_model_export_wrappers() -> None:
+    model_pkg = importlib.import_module("ometeotl_core.model")
+
+    for module_info in pkgutil.walk_packages(
+        model_pkg.__path__, model_pkg.__name__ + "."
+    ):
+        module = importlib.import_module(module_info.name)
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module.__name__:
+                continue
+            _wrap_method(cls, "to_dict", "exports/model/to_dict")
+            _wrap_method(cls, "to_llm_view", "exports/model/to_llm_view")
+
+
+def _install_io_export_wrappers() -> None:
+    io_module = importlib.import_module("ometeotl_core.io")
+    _wrap_function(io_module, "world_to_json", "exports/io/world_to_json", "json")
+    _wrap_function(io_module, "world_to_yaml", "exports/io/world_to_yaml", "yaml")
+    _wrap_function(io_module, "world_to_llm_view", "exports/io/world_to_llm_view", "dict")
+
+
+_install_model_export_wrappers()
+_install_io_export_wrappers()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item: pytest.Item):
+    global _CURRENT_TEST_NODEID
+
+    _CURRENT_TEST_NODEID = item.nodeid
+    _LAYER_COUNTERS.clear()
+    yield
+    _CURRENT_TEST_NODEID = ""

--- a/tests/ometeotl_core/_artifact_utils.py
+++ b/tests/ometeotl_core/_artifact_utils.py
@@ -1,0 +1,47 @@
+"""Helpers for writing local test artifacts under local_lab.
+
+Artifacts are intentionally written outside tracked source folders to keep
+audit snapshots accessible without polluting the repository history.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_text_artifact(
+    *,
+    layer: str,
+    name: str,
+    content: str,
+    extension: str,
+) -> Path:
+    """Write one text artifact under local_lab/artifacts/<layer>/.
+
+    The output filename is stable and is overwritten on each run to avoid
+    data accumulation.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    artifact_dir = repo_root / "local_lab" / "artifacts" / layer
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    normalized_extension = extension.lstrip(".")
+    artifact_path = artifact_dir / f"{name}.{normalized_extension}"
+    artifact_path.write_text(content, encoding="utf-8")
+    return artifact_path
+
+
+def write_json_artifact(*, layer: str, name: str, payload: Any) -> Path:
+    """Write one JSON artifact under local_lab/artifacts/<layer>/.
+
+    The output filename is stable and is overwritten on each run to avoid
+    data accumulation.
+    """
+    return write_text_artifact(
+        layer=layer,
+        name=name,
+        content=json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        extension="json",
+    )

--- a/tests/ometeotl_core/generation/__init__.py
+++ b/tests/ometeotl_core/generation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the contextual generation layer."""

--- a/tests/ometeotl_core/generation/test_context_builder.py
+++ b/tests/ometeotl_core/generation/test_context_builder.py
@@ -1,4 +1,4 @@
-"""Tests for class-based contextual builders (Step 5)."""
+"""Tests for class-based contextual builders."""
 
 import pytest
 
@@ -31,7 +31,7 @@ def test_generation_context_exposes_rules_and_constraints_in_merged_context():
     assert merged["generation"]["constraints"] == {"max_links": 4}
 
 
-def test_default_contextual_builders_cover_core_step5_kinds():
+def test_default_contextual_builders_cover_core_context_kinds():
     builder_map = default_contextual_builders()
 
     assert sorted(builder_map.keys()) == [

--- a/tests/ometeotl_core/generation/test_context_builder.py
+++ b/tests/ometeotl_core/generation/test_context_builder.py
@@ -1,0 +1,80 @@
+"""Tests for class-based contextual builders (Step 5)."""
+
+import pytest
+
+from ometeotl_core.generation import (
+    ActorContextualBuilder,
+    GenerationContext,
+    GenerationPlacement,
+    WorldContextualBuilder,
+    build_with_context_builder,
+    default_contextual_builders,
+)
+from ometeotl_core.model.actors import Actor
+from ometeotl_core.model.world import World
+
+
+def test_generation_context_exposes_rules_and_constraints_in_merged_context():
+    context = GenerationContext(
+        kind="actor",
+        id="actor-cb-1",
+        metadata={"source": "test"},
+        rules={"label_policy": "strict"},
+        constraints={"max_links": 4},
+    )
+
+    merged = context.merged_context()
+
+    assert "generation" in merged
+    assert merged["generation"]["source"] == "test"
+    assert merged["generation"]["rules"] == {"label_policy": "strict"}
+    assert merged["generation"]["constraints"] == {"max_links": 4}
+
+
+def test_default_contextual_builders_cover_core_step5_kinds():
+    builder_map = default_contextual_builders()
+
+    assert sorted(builder_map.keys()) == [
+        "actor",
+        "goal",
+        "perception",
+        "strategy",
+        "world",
+    ]
+
+
+def test_build_with_context_builder_builds_actor():
+    generated = build_with_context_builder(
+        GenerationContext(kind="actor", id="actor-cb-2", label="Builder Actor")
+    )
+
+    assert isinstance(generated, Actor)
+    assert generated.id == "actor-cb-2"
+    assert generated.label == "Builder Actor"
+
+
+def test_builder_raises_on_kind_mismatch():
+    builder = ActorContextualBuilder()
+
+    with pytest.raises(ValueError, match="expects kind 'actor'"):
+        builder.build(GenerationContext(kind="world", id="world-cb-1"))
+
+
+def test_world_contextual_builder_builds_nested_world_with_placements():
+    builder = WorldContextualBuilder()
+    world = builder.build(
+        GenerationContext(
+            kind="world",
+            id="world-cb-3",
+            spaces=[GenerationContext(kind="space", id="zone-cb")],
+            actors=[GenerationContext(kind="actor", id="actor-cb-3")],
+            placements=[
+                GenerationPlacement(object_id="actor-cb-3", space_id="zone-cb")
+            ],
+        )
+    )
+
+    assert isinstance(world, World)
+    assert world.get_space("zone-cb") is not None
+    assert world.model_registry.exists("actor-cb-3")
+    assert "actor-cb-3" in world.space_object_graph.list_objects_in_space("zone-cb")

--- a/tests/ometeotl_core/generation/test_context_pipeline.py
+++ b/tests/ometeotl_core/generation/test_context_pipeline.py
@@ -449,6 +449,30 @@ def test_pipeline_registration_policy_require_without_world_raises():
         )
 
 
+def test_pipeline_registration_policy_require_rejects_non_model_generated(monkeypatch):
+    import ometeotl_core.generation.pipeline as pipeline_module
+
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-registry-non-model-require")
+    world.register_object(Actor(id="actor-1"))
+
+    def _fake_build(_context: GenerationContext):
+        return {"id": "not-a-model-object"}
+
+    monkeypatch.setattr(pipeline_module, "build_from_context", _fake_build)
+
+    with pytest.raises(TypeError, match="Registration policy 'require' failed"):
+        pipeline.generate(
+            GenerationContext(
+                kind="goal",
+                id="goal-non-model-require",
+                registration_policy="require",
+                metadata={"actor_id": "actor-1", "kind": "final"},
+            ),
+            world=world,
+        )
+
+
 def test_pipeline_registration_if_available_without_world_adds_diagnostic():
     pipeline = ContextualGenerationPipeline()
     result = pipeline.generate(

--- a/tests/ometeotl_core/generation/test_context_pipeline.py
+++ b/tests/ometeotl_core/generation/test_context_pipeline.py
@@ -1,5 +1,7 @@
 """Tests for contextual generation pipeline."""
 
+from typing import Any, cast
+
 import pytest
 
 from tests.ometeotl_core._artifact_utils import write_json_artifact
@@ -510,6 +512,41 @@ def test_pipeline_corrective_update_replaces_specified_relations():
     assert actor.relations["resource"] == ["resource-c"]
 
 
+def test_pipeline_partial_update_preserves_falsy_non_string_context_keys():
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-update-falsy-keys")
+    actor_zero = Actor(id="actor-update-falsy-key-zero")
+    actor_false = Actor(id="actor-update-falsy-key-false")
+    world.register_object(actor_zero)
+    world.register_object(actor_false)
+
+    zero_result = pipeline.generate(
+        GenerationContext(
+            kind="actor",
+            id="actor-update-falsy-key-zero",
+            operation="partial_update",
+            context=cast(dict[str, Any], {0: "zero-key", "": "ignored-empty"}),
+        ),
+        world=world,
+    )
+
+    false_result = pipeline.generate(
+        GenerationContext(
+            kind="actor",
+            id="actor-update-falsy-key-false",
+            operation="partial_update",
+            context=cast(dict[str, Any], {False: "false-key"}),
+        ),
+        world=world,
+    )
+
+    assert zero_result.generated is actor_zero
+    assert false_result.generated is actor_false
+    assert cast(dict[Any, Any], actor_zero.context)[0] == "zero-key"
+    assert "" not in actor_zero.context
+    assert cast(dict[Any, Any], actor_false.context)[False] == "false-key"
+
+
 def test_pipeline_partial_update_context_is_blocked_by_authority_mode():
     pipeline = ContextualGenerationPipeline()
     world = World(id="world-update-authority-1")
@@ -603,6 +640,49 @@ def test_pipeline_perception_generation_rejects_component_link_missing_component
                             "link_id": "link-1",
                             "composite_id": "actor-1",
                             "epistemic_status": "projected",
+                        }
+                    ],
+                },
+            )
+        )
+
+
+def test_pipeline_perception_generation_rejects_membership_missing_payload():
+    pipeline = ContextualGenerationPipeline()
+
+    with pytest.raises(ValueError, match="requires 'membership' payload"):
+        pipeline.generate(
+            GenerationContext(
+                kind="perception",
+                id="perception-invalid-membership-missing",
+                metadata={
+                    "actor_id": "actor-1",
+                    "source_id": "world-1",
+                    "perceived_memberships": [
+                        {
+                            "epistemic_status": "certain",
+                        }
+                    ],
+                },
+            )
+        )
+
+
+def test_pipeline_perception_generation_rejects_membership_empty_mapping():
+    pipeline = ContextualGenerationPipeline()
+
+    with pytest.raises(ValueError, match="requires non-empty 'membership' mapping"):
+        pipeline.generate(
+            GenerationContext(
+                kind="perception",
+                id="perception-invalid-membership-empty",
+                metadata={
+                    "actor_id": "actor-1",
+                    "source_id": "world-1",
+                    "perceived_memberships": [
+                        {
+                            "membership": {},
+                            "epistemic_status": "certain",
                         }
                     ],
                 },

--- a/tests/ometeotl_core/generation/test_context_pipeline.py
+++ b/tests/ometeotl_core/generation/test_context_pipeline.py
@@ -1,5 +1,7 @@
 """Tests for contextual generation pipeline."""
 
+import pytest
+
 from tests.ometeotl_core._artifact_utils import write_json_artifact
 
 from ometeotl_core.generation import (
@@ -11,8 +13,45 @@ from ometeotl_core.model.actions import Action
 from ometeotl_core.model.actors import Actor
 from ometeotl_core.model.goals import Goal
 from ometeotl_core.model.perception import Perception
+from ometeotl_core.model.spaces import Space
 from ometeotl_core.model.strategies import Strategy
 from ometeotl_core.model.world import World
+from ometeotl_core.validation import (
+    SEVERITY_ERROR,
+    ValidationContext,
+    ValidationIssue,
+    ValidationPipeline,
+    ValidationResult,
+)
+
+
+class _AlwaysPassValidator:
+    @property
+    def name(self) -> str:
+        return "always_pass"
+
+    def validate(self, obj, context: ValidationContext) -> ValidationResult:
+        return ValidationResult(stage=context.stage, policy_mode=context.policy_mode)
+
+
+class _AlwaysFailValidator:
+    @property
+    def name(self) -> str:
+        return "always_fail"
+
+    def validate(self, obj, context: ValidationContext) -> ValidationResult:
+        return ValidationResult(
+            stage=context.stage,
+            policy_mode=context.policy_mode,
+            issues=[
+                ValidationIssue(
+                    code="GEN-FAIL",
+                    severity=SEVERITY_ERROR,
+                    message="Synthetic validation failure for pipeline testing",
+                    object_id=str(getattr(obj, "id", "")),
+                )
+            ],
+        )
 
 
 def test_pipeline_generates_world_with_registered_objects_and_placements():
@@ -229,3 +268,256 @@ def test_generation_audit_writes_local_lab_artifact():
     )
 
     assert artifact_path.name == "generation_snapshot.json"
+
+
+def test_pipeline_validation_requested_without_pipeline_records_diagnostic():
+    pipeline = ContextualGenerationPipeline()
+    actor_context = GenerationContext(
+        kind="actor",
+        id="actor-validate-missing-pipeline",
+        validate=True,
+    )
+
+    result = pipeline.generate(actor_context)
+
+    assert result.validation is None
+    assert any(
+        "Validation requested but no validation pipeline is configured" in item
+        for item in result.diagnostics
+    )
+
+
+def test_pipeline_validation_success_with_configured_pipeline():
+    pipeline = ContextualGenerationPipeline(
+        validation_pipeline=ValidationPipeline(validators=[_AlwaysPassValidator()])
+    )
+    actor_context = GenerationContext(
+        kind="actor",
+        id="actor-validate-pass",
+        validate=True,
+    )
+
+    result = pipeline.generate(actor_context)
+
+    assert result.validation is not None
+    assert result.validation.valid is True
+    assert result.validation.metadata["executed_validators"] == ["always_pass"]
+    assert not any("failed validation" in item for item in result.diagnostics)
+
+
+def test_pipeline_validation_failure_emits_diagnostic_and_result():
+    pipeline = ContextualGenerationPipeline(
+        validation_pipeline=ValidationPipeline(validators=[_AlwaysFailValidator()])
+    )
+    actor_context = GenerationContext(
+        kind="actor",
+        id="actor-validate-fail",
+        validate=True,
+    )
+
+    result = pipeline.generate(actor_context)
+
+    assert result.validation is not None
+    assert result.validation.valid is False
+    assert result.validation.summary["error"] == 1
+    assert any("failed validation" in item for item in result.diagnostics)
+
+
+def test_pipeline_registers_generated_goal_when_world_context_is_required():
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-registry-1")
+    world.register_object(Actor(id="actor-1"))
+
+    goal_context = GenerationContext(
+        kind="goal",
+        id="goal-registered-1",
+        registration_policy="require",
+        metadata={
+            "actor_id": "actor-1",
+            "kind": "final",
+            "target_condition": {"state": "safe"},
+        },
+    )
+
+    result = pipeline.generate(goal_context, world=world)
+
+    assert world.model_registry.get("goal-registered-1") is result.generated
+    assert any("Registered generated goal" in item for item in result.diagnostics)
+
+
+def test_pipeline_registers_generated_strategy_and_action_when_world_available():
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-registry-2")
+    world.add_space(Space(id="zone-a"))
+
+    strategy_result = pipeline.generate(
+        GenerationContext(
+            kind="strategy",
+            id="strategy-registered-1",
+            registration_policy="if_available",
+            metadata={
+                "actor_id": "actor-1",
+                "goal_id": "goal-1",
+                "action_id": "action-1",
+            },
+        ),
+        world=world,
+    )
+    action_result = pipeline.generate(
+        GenerationContext(
+            kind="action",
+            id="action-registered-1",
+            registration_policy="if_available",
+            metadata={
+                "actor_id": "actor-1",
+                "world_id": world.id,
+                "space_id": "zone-a",
+                "action_type": "move",
+            },
+        ),
+        world=world,
+    )
+
+    assert (
+        world.model_registry.get("strategy-registered-1") is strategy_result.generated
+    )
+    assert world.model_registry.get("action-registered-1") is action_result.generated
+
+
+def test_pipeline_registration_policy_require_without_world_raises():
+    pipeline = ContextualGenerationPipeline()
+
+    with pytest.raises(ValueError):
+        pipeline.generate(
+            GenerationContext(
+                kind="goal",
+                id="goal-missing-world",
+                registration_policy="require",
+                metadata={"actor_id": "actor-1", "kind": "final"},
+            )
+        )
+
+
+def test_pipeline_registration_if_available_without_world_adds_diagnostic():
+    pipeline = ContextualGenerationPipeline()
+    result = pipeline.generate(
+        GenerationContext(
+            kind="goal",
+            id="goal-skip-world",
+            registration_policy="if_available",
+            metadata={"actor_id": "actor-1", "kind": "final"},
+        )
+    )
+
+    assert any("Skipped registration" in item for item in result.diagnostics)
+
+
+def test_pipeline_partial_update_merges_attributes_state_and_relations():
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-update-1")
+    actor = Actor(id="actor-update-1")
+    actor.set_attribute("existing", "value")
+    actor.add_relation("resource", "resource-a")
+    world.register_object(actor)
+
+    result = pipeline.generate(
+        GenerationContext(
+            kind="actor",
+            id="actor-update-1",
+            operation="partial_update",
+            attributes={"new": "value"},
+            state={"mood": "focused"},
+            relations={"resource": ["resource-b"]},
+        ),
+        world=world,
+    )
+
+    assert result.generated is actor
+    assert actor.attributes["existing"] == "value"
+    assert actor.attributes["new"] == "value"
+    assert actor.state["mood"] == "focused"
+    assert actor.relations["resource"] == ["resource-a", "resource-b"]
+
+
+def test_pipeline_corrective_update_replaces_specified_relations():
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-update-2")
+    actor = Actor(id="actor-update-2")
+    actor.add_relation("resource", "resource-a")
+    actor.add_relation("resource", "resource-b")
+    world.register_object(actor)
+
+    result = pipeline.generate(
+        GenerationContext(
+            kind="actor",
+            id="actor-update-2",
+            operation="corrective_update",
+            relations={"resource": ["resource-c"]},
+        ),
+        world=world,
+    )
+
+    assert result.generated is actor
+    assert actor.relations["resource"] == ["resource-c"]
+
+
+def test_pipeline_update_operation_requires_existing_target():
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-update-3")
+
+    with pytest.raises(ValueError):
+        pipeline.generate(
+            GenerationContext(
+                kind="actor",
+                id="missing-actor",
+                operation="partial_update",
+                attributes={"new": "value"},
+            ),
+            world=world,
+        )
+
+
+def test_pipeline_perception_generation_rejects_component_link_missing_link_id():
+    pipeline = ContextualGenerationPipeline()
+
+    with pytest.raises(ValueError):
+        pipeline.generate(
+            GenerationContext(
+                kind="perception",
+                id="perception-invalid-link-id",
+                metadata={
+                    "actor_id": "actor-1",
+                    "source_id": "world-1",
+                    "perceived_component_links": [
+                        {
+                            "composite_id": "actor-1",
+                            "component_id": "actor-2",
+                            "epistemic_status": "projected",
+                        }
+                    ],
+                },
+            )
+        )
+
+
+def test_pipeline_perception_generation_rejects_component_link_missing_component_id():
+    pipeline = ContextualGenerationPipeline()
+
+    with pytest.raises(ValueError):
+        pipeline.generate(
+            GenerationContext(
+                kind="perception",
+                id="perception-invalid-component-id",
+                metadata={
+                    "actor_id": "actor-1",
+                    "source_id": "world-1",
+                    "perceived_component_links": [
+                        {
+                            "link_id": "link-1",
+                            "composite_id": "actor-1",
+                            "epistemic_status": "projected",
+                        }
+                    ],
+                },
+            )
+        )

--- a/tests/ometeotl_core/generation/test_context_pipeline.py
+++ b/tests/ometeotl_core/generation/test_context_pipeline.py
@@ -13,6 +13,7 @@ from ometeotl_core.model.actions import Action
 from ometeotl_core.model.actors import Actor
 from ometeotl_core.model.goals import Goal
 from ometeotl_core.model.perception import Perception
+from ometeotl_core.model.resources import Resource
 from ometeotl_core.model.spaces import Space
 from ometeotl_core.model.strategies import Strategy
 from ometeotl_core.model.world import World
@@ -109,6 +110,24 @@ def test_pipeline_generates_goal_from_metadata():
     assert result.generated.actor_id == "actor-1"
     assert result.generated.priority == 0.7
     assert result.generated.target_condition == {"state": "safe"}
+
+
+def test_pipeline_generates_goal_preserving_zero_priority():
+    pipeline = ContextualGenerationPipeline()
+    goal_context = GenerationContext(
+        kind="goal",
+        id="goal-gen-priority-zero",
+        metadata={
+            "actor_id": "actor-1",
+            "kind": "intermediate",
+            "priority": 0.0,
+        },
+    )
+
+    result = pipeline.generate(goal_context)
+
+    assert isinstance(result.generated, Goal)
+    assert result.generated.priority == 0.0
 
 
 def test_pipeline_generates_strategy_with_default_single_node():
@@ -384,6 +403,36 @@ def test_pipeline_registers_generated_strategy_and_action_when_world_available()
     assert world.model_registry.get("action-registered-1") is action_result.generated
 
 
+def test_pipeline_registers_generated_actor_and_resource_when_world_available():
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-registry-actor-resource")
+
+    actor_result = pipeline.generate(
+        GenerationContext(
+            kind="actor",
+            id="actor-registered-policy",
+            registration_policy="if_available",
+        ),
+        world=world,
+    )
+    resource_result = pipeline.generate(
+        GenerationContext(
+            kind="resource",
+            id="resource-registered-policy",
+            registration_policy="if_available",
+        ),
+        world=world,
+    )
+
+    assert isinstance(actor_result.generated, Actor)
+    assert isinstance(resource_result.generated, Resource)
+    assert world.model_registry.get("actor-registered-policy") is actor_result.generated
+    assert (
+        world.model_registry.get("resource-registered-policy")
+        is resource_result.generated
+    )
+
+
 def test_pipeline_registration_policy_require_without_world_raises():
     pipeline = ContextualGenerationPipeline()
 
@@ -459,6 +508,44 @@ def test_pipeline_corrective_update_replaces_specified_relations():
 
     assert result.generated is actor
     assert actor.relations["resource"] == ["resource-c"]
+
+
+def test_pipeline_partial_update_context_is_blocked_by_authority_mode():
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-update-authority-1")
+    actor = Actor(id="actor-update-authority-1")
+    world.register_object(actor)
+    world.enable_authority_mode("secret")
+
+    with pytest.raises(PermissionError):
+        pipeline.generate(
+            GenerationContext(
+                kind="actor",
+                id="actor-update-authority-1",
+                operation="partial_update",
+                context={"risk": "high"},
+            ),
+            world=world,
+        )
+
+
+def test_pipeline_corrective_update_context_is_blocked_by_authority_mode():
+    pipeline = ContextualGenerationPipeline()
+    world = World(id="world-update-authority-2")
+    actor = Actor(id="actor-update-authority-2")
+    world.register_object(actor)
+    world.enable_authority_mode("secret")
+
+    with pytest.raises(PermissionError):
+        pipeline.generate(
+            GenerationContext(
+                kind="actor",
+                id="actor-update-authority-2",
+                operation="corrective_update",
+                context={"risk": "high"},
+            ),
+            world=world,
+        )
 
 
 def test_pipeline_update_operation_requires_existing_target():

--- a/tests/ometeotl_core/generation/test_context_pipeline.py
+++ b/tests/ometeotl_core/generation/test_context_pipeline.py
@@ -1,0 +1,231 @@
+"""Tests for contextual generation pipeline."""
+
+from tests.ometeotl_core._artifact_utils import write_json_artifact
+
+from ometeotl_core.generation import (
+    ContextualGenerationPipeline,
+    GenerationContext,
+    GenerationPlacement,
+)
+from ometeotl_core.model.actions import Action
+from ometeotl_core.model.actors import Actor
+from ometeotl_core.model.goals import Goal
+from ometeotl_core.model.perception import Perception
+from ometeotl_core.model.strategies import Strategy
+from ometeotl_core.model.world import World
+
+
+def test_pipeline_generates_world_with_registered_objects_and_placements():
+    pipeline = ContextualGenerationPipeline()
+    world_context = GenerationContext(
+        kind="world",
+        id="world-gen-1",
+        label="Generated World",
+        spaces=[GenerationContext(kind="space", id="zone-a")],
+        actors=[GenerationContext(kind="actor", id="actor-a", label="Alice")],
+        resources=[GenerationContext(kind="resource", id="resource-a")],
+        placements=[GenerationPlacement(object_id="actor-a", space_id="zone-a")],
+    )
+
+    result = pipeline.generate(world_context)
+
+    assert isinstance(result.generated, World)
+    assert result.generated.get_space("zone-a") is not None
+    assert result.generated.model_registry.get("actor-a") is not None
+    assert result.generated.model_registry.get("resource-a") is not None
+    assert "actor-a" in result.generated.space_object_graph.list_objects_in_space(
+        "zone-a"
+    )
+
+
+def test_pipeline_generates_actor_with_label_promoted_to_attributes():
+    pipeline = ContextualGenerationPipeline()
+    actor_context = GenerationContext(
+        kind="actor", id="actor-gen-1", label="Generated Actor"
+    )
+
+    result = pipeline.generate(actor_context)
+
+    assert isinstance(result.generated, Actor)
+    assert result.generated.label == "Generated Actor"
+
+
+def test_pipeline_generates_goal_from_metadata():
+    pipeline = ContextualGenerationPipeline()
+    goal_context = GenerationContext(
+        kind="goal",
+        id="goal-gen-1",
+        metadata={
+            "actor_id": "actor-1",
+            "kind": "final",
+            "priority": 0.7,
+            "status": "active",
+            "target_condition": {"state": "safe"},
+        },
+    )
+
+    result = pipeline.generate(goal_context)
+
+    assert isinstance(result.generated, Goal)
+    assert result.generated.actor_id == "actor-1"
+    assert result.generated.priority == 0.7
+    assert result.generated.target_condition == {"state": "safe"}
+
+
+def test_pipeline_generates_strategy_with_default_single_node():
+    pipeline = ContextualGenerationPipeline()
+    strategy_context = GenerationContext(
+        kind="strategy",
+        id="strategy-gen-1",
+        metadata={
+            "actor_id": "actor-1",
+            "goal_id": "goal-1",
+            "root_node_id": "node-root",
+            "action_id": "action-1",
+        },
+    )
+
+    result = pipeline.generate(strategy_context)
+
+    assert isinstance(result.generated, Strategy)
+    assert result.generated.actor_id == "actor-1"
+    assert result.generated.root_node_id == "node-root"
+    assert len(result.generated.nodes) == 1
+    assert result.generated.nodes[0].action_id == "action-1"
+
+
+def test_pipeline_generates_action_from_metadata():
+    pipeline = ContextualGenerationPipeline()
+    action_context = GenerationContext(
+        kind="action",
+        id="action-gen-1",
+        metadata={
+            "actor_id": "actor-1",
+            "world_id": "world-1",
+            "space_id": "zone-a",
+            "action_type": "move",
+        },
+    )
+
+    result = pipeline.generate(action_context)
+
+    assert isinstance(result.generated, Action)
+    assert result.generated.actor_id == "actor-1"
+    assert result.generated.world_id == "world-1"
+    assert result.generated.space_id == "zone-a"
+    assert result.generated.action_type == "move"
+
+
+def test_pipeline_generates_perception_from_context_metadata():
+    pipeline = ContextualGenerationPipeline()
+    perception_context = GenerationContext(
+        kind="perception",
+        id="perception-gen-1",
+        metadata={
+            "actor_id": "actor-1",
+            "source_id": "world-1",
+            "timestamp": 42,
+            "perceived_spaces": {
+                "zone-a": {
+                    "space": {"id": "zone-a", "object_type": "space"},
+                    "epistemic_status": "certain",
+                }
+            },
+            "perceived_memberships": [
+                {
+                    "membership": {
+                        "object_id": "actor-1",
+                        "space_id": "zone-a",
+                        "role": "occupies",
+                    },
+                    "epistemic_status": "believed",
+                }
+            ],
+            "perceived_relations": [
+                {
+                    "relation": {
+                        "source_space_id": "zone-a",
+                        "target_space_id": "zone-b",
+                        "relation_type": "adjacent_to",
+                    },
+                    "epistemic_status": "hypothesis",
+                }
+            ],
+            "perceived_component_links": [
+                {
+                    "link_id": "link-1",
+                    "composite_id": "actor-1",
+                    "component_id": "actor-2",
+                    "epistemic_status": "projected",
+                }
+            ],
+        },
+    )
+
+    result = pipeline.generate(perception_context)
+
+    assert isinstance(result.generated, Perception)
+    assert result.generated.actor_id == "actor-1"
+    assert result.generated.source_id == "world-1"
+    assert result.generated.timestamp == 42
+    assert sorted(result.generated.perceived_spaces.keys()) == ["zone-a"]
+    assert len(result.generated.perceived_memberships) == 1
+    assert len(result.generated.perceived_relations) == 1
+    assert len(result.generated.perceived_component_links) == 1
+
+
+def test_generation_audit_writes_local_lab_artifact():
+    """Write a stable generation snapshot under local_lab for audit review."""
+    pipeline = ContextualGenerationPipeline()
+
+    generated_world = pipeline.generate(
+        GenerationContext(
+            kind="world",
+            id="world-audit-1",
+            spaces=[GenerationContext(kind="space", id="zone-a")],
+            actors=[GenerationContext(kind="actor", id="actor-a", label="Alice")],
+            resources=[GenerationContext(kind="resource", id="resource-a")],
+            placements=[GenerationPlacement(object_id="actor-a", space_id="zone-a")],
+        )
+    ).generated
+    generated_strategy = pipeline.generate(
+        GenerationContext(
+            kind="strategy",
+            id="strategy-audit-1",
+            metadata={
+                "actor_id": "actor-a",
+                "goal_id": "goal-a",
+                "root_node_id": "node-root",
+                "action_id": "action-a",
+            },
+        )
+    ).generated
+    generated_perception = pipeline.generate(
+        GenerationContext(
+            kind="perception",
+            id="perception-audit-1",
+            metadata={
+                "actor_id": "actor-a",
+                "source_id": "world-audit-1",
+                "perceived_spaces": {
+                    "zone-a": {
+                        "space": {"id": "zone-a", "object_type": "space"},
+                        "epistemic_status": "certain",
+                    }
+                },
+            },
+        )
+    ).generated
+
+    payload = {
+        "world": generated_world.to_dict(),
+        "strategy": generated_strategy.to_dict(),
+        "perception": generated_perception.to_dict(),
+    }
+    artifact_path = write_json_artifact(
+        layer="generation",
+        name="generation_snapshot",
+        payload=payload,
+    )
+
+    assert artifact_path.name == "generation_snapshot.json"

--- a/tests/ometeotl_core/generation/test_llm_integration.py
+++ b/tests/ometeotl_core/generation/test_llm_integration.py
@@ -7,6 +7,34 @@ from ometeotl_core.generation import (
     GenerationContext,
     LLMGenerationAdapter,
 )
+from ometeotl_core.validation import (
+    SEVERITY_ERROR,
+    ValidationContext,
+    ValidationIssue,
+    ValidationPipeline,
+    ValidationResult,
+)
+
+
+class _FailWithSuggestionValidator:
+    @property
+    def name(self) -> str:
+        return "fail_with_suggestion"
+
+    def validate(self, obj, context: ValidationContext) -> ValidationResult:
+        return ValidationResult(
+            stage=context.stage,
+            policy_mode=context.policy_mode,
+            issues=[
+                ValidationIssue(
+                    code="GEN-SUGGEST",
+                    severity=SEVERITY_ERROR,
+                    message="Synthetic failure with fix guidance",
+                    object_id=str(getattr(obj, "id", "")),
+                    suggestion="Set required actor_id in metadata",
+                )
+            ],
+        )
 
 
 def test_llm_adapter_refines_context_from_json_overrides():
@@ -58,6 +86,9 @@ def test_pipeline_generate_hybrid_uses_llm_refined_context():
     assert result.generated.id == "actor-hybrid-3"
     assert result.generated.label == "Hybrid Actor"
     assert result.generated.attributes["kind"] == "custom"
+    assert "stage: text_generation" in result.diagnostics
+    assert "stage: parsing" in result.diagnostics
+    assert "stage: instantiation (create)" in result.diagnostics
 
 
 def test_pipeline_generate_hybrid_preserves_generation_when_fallback_needed():
@@ -77,3 +108,59 @@ def test_pipeline_generate_hybrid_preserves_generation_when_fallback_needed():
     assert result.generated.id == "actor-hybrid-4"
     assert result.generated.label == "Base"
     assert any("falling back" in msg.lower() for msg in result.diagnostics)
+
+
+def test_pipeline_generate_from_text_response_parses_and_instantiates():
+    adapter = LLMGenerationAdapter(text_generator=lambda prompt: "{}")
+    pipeline = ContextualGenerationPipeline()
+
+    result = pipeline.generate_from_text_response(
+        GenerationContext(kind="actor", id="actor-hybrid-5", label="Base"),
+        raw_response='{"label": "FromText", "attributes": {"kind": "custom"}}',
+        llm_adapter=adapter,
+    )
+
+    assert result.generated.id == "actor-hybrid-5"
+    assert result.generated.label == "FromText"
+    assert "stage: parsing" in result.diagnostics
+    assert "stage: instantiation (create)" in result.diagnostics
+
+
+def test_pipeline_reports_uncertainty_zones_from_context_metadata():
+    adapter = LLMGenerationAdapter(text_generator=lambda prompt: "{}")
+    pipeline = ContextualGenerationPipeline()
+
+    result = pipeline.generate_hybrid(
+        GenerationContext(
+            kind="actor",
+            id="actor-hybrid-6",
+            metadata={"uncertainty_zones": ["zone-a", "zone-b"]},
+        ),
+        llm_adapter=adapter,
+    )
+
+    assert result.uncertainty_zones == ["zone-a", "zone-b"]
+    assert any("uncertainty zones" in msg.lower() for msg in result.diagnostics)
+
+
+def test_pipeline_builds_repair_suggestions_on_validation_failure():
+    adapter = LLMGenerationAdapter(text_generator=lambda prompt: "{}")
+    pipeline = ContextualGenerationPipeline(
+        validation_pipeline=ValidationPipeline(
+            validators=[_FailWithSuggestionValidator()]
+        )
+    )
+
+    result = pipeline.generate_hybrid(
+        GenerationContext(
+            kind="actor",
+            id="actor-hybrid-7",
+            validate=True,
+        ),
+        llm_adapter=adapter,
+    )
+
+    assert result.validation is not None
+    assert result.validation.valid is False
+    assert result.repair_suggestions == ["Set required actor_id in metadata"]
+    assert any("Suggested repair" in msg for msg in result.diagnostics)

--- a/tests/ometeotl_core/generation/test_llm_integration.py
+++ b/tests/ometeotl_core/generation/test_llm_integration.py
@@ -70,6 +70,26 @@ def test_llm_adapter_falls_back_on_invalid_json_response():
     assert any("falling back" in msg.lower() for msg in refinement.diagnostics)
 
 
+def test_llm_adapter_parses_markdown_wrapped_json_response():
+        def fake_generator(prompt: str) -> str:
+                del prompt
+                return """```json
+{
+    \"label\": \"Wrapped\",
+    \"attributes\": {\"kind\": \"custom\"}
+}
+```"""
+
+        adapter = LLMGenerationAdapter(text_generator=fake_generator)
+        base_context = GenerationContext(kind="actor", id="actor-hybrid-2c", label="Base")
+
+        refinement = adapter.refine_context(base_context)
+
+        assert refinement.used_fallback is False
+        assert refinement.refined_context.label == "Wrapped"
+        assert refinement.refined_context.attributes["kind"] == "custom"
+
+
 def test_llm_adapter_falls_back_when_text_generator_raises():
     def failing_generator(prompt: str) -> str:
         del prompt

--- a/tests/ometeotl_core/generation/test_llm_integration.py
+++ b/tests/ometeotl_core/generation/test_llm_integration.py
@@ -1,0 +1,79 @@
+"""Tests for generation LLM integration adapter and hybrid pipeline mode."""
+
+from __future__ import annotations
+
+from ometeotl_core.generation import (
+    ContextualGenerationPipeline,
+    GenerationContext,
+    LLMGenerationAdapter,
+)
+
+
+def test_llm_adapter_refines_context_from_json_overrides():
+    prompts: list[str] = []
+
+    def fake_generator(prompt: str) -> str:
+        prompts.append(prompt)
+        return '{"attributes": {"kind": "custom"}, "label": "Refined"}'
+
+    adapter = LLMGenerationAdapter(text_generator=fake_generator)
+    base_context = GenerationContext(kind="actor", id="actor-hybrid-1", label="Base")
+
+    refinement = adapter.refine_context(base_context)
+
+    assert prompts
+    assert refinement.used_fallback is False
+    assert refinement.refined_context.label == "Refined"
+    assert refinement.refined_context.attributes["kind"] == "custom"
+
+
+def test_llm_adapter_falls_back_on_invalid_json_response():
+    def fake_generator(prompt: str) -> str:
+        del prompt
+        return "not-json"
+
+    adapter = LLMGenerationAdapter(text_generator=fake_generator)
+    base_context = GenerationContext(kind="actor", id="actor-hybrid-2", label="Base")
+
+    refinement = adapter.refine_context(base_context)
+
+    assert refinement.used_fallback is True
+    assert refinement.refined_context.id == "actor-hybrid-2"
+    assert any("falling back" in msg.lower() for msg in refinement.diagnostics)
+
+
+def test_pipeline_generate_hybrid_uses_llm_refined_context():
+    def fake_generator(prompt: str) -> str:
+        del prompt
+        return '{"label": "Hybrid Actor", "attributes": {"kind": "custom"}}'
+
+    adapter = LLMGenerationAdapter(text_generator=fake_generator)
+    pipeline = ContextualGenerationPipeline()
+
+    result = pipeline.generate_hybrid(
+        GenerationContext(kind="actor", id="actor-hybrid-3", label="Base"),
+        llm_adapter=adapter,
+    )
+
+    assert result.generated.id == "actor-hybrid-3"
+    assert result.generated.label == "Hybrid Actor"
+    assert result.generated.attributes["kind"] == "custom"
+
+
+def test_pipeline_generate_hybrid_preserves_generation_when_fallback_needed():
+    def fake_generator(prompt: str) -> str:
+        del prompt
+        return "invalid-json"
+
+    adapter = LLMGenerationAdapter(text_generator=fake_generator)
+    pipeline = ContextualGenerationPipeline()
+
+    result = pipeline.generate_hybrid(
+        GenerationContext(kind="actor", id="actor-hybrid-4", label="Base"),
+        llm_adapter=adapter,
+        fallback_to_base=True,
+    )
+
+    assert result.generated.id == "actor-hybrid-4"
+    assert result.generated.label == "Base"
+    assert any("falling back" in msg.lower() for msg in result.diagnostics)

--- a/tests/ometeotl_core/generation/test_llm_integration.py
+++ b/tests/ometeotl_core/generation/test_llm_integration.py
@@ -70,6 +70,22 @@ def test_llm_adapter_falls_back_on_invalid_json_response():
     assert any("falling back" in msg.lower() for msg in refinement.diagnostics)
 
 
+def test_llm_adapter_falls_back_when_text_generator_raises():
+    def failing_generator(prompt: str) -> str:
+        del prompt
+        raise RuntimeError("provider timeout")
+
+    adapter = LLMGenerationAdapter(text_generator=failing_generator)
+    base_context = GenerationContext(kind="actor", id="actor-hybrid-2b", label="Base")
+
+    refinement = adapter.refine_context(base_context, fallback_to_base=True)
+
+    assert refinement.used_fallback is True
+    assert refinement.refined_context.id == "actor-hybrid-2b"
+    assert refinement.raw_response == ""
+    assert any("generation failed" in msg.lower() for msg in refinement.diagnostics)
+
+
 def test_pipeline_generate_hybrid_uses_llm_refined_context():
     def fake_generator(prompt: str) -> str:
         del prompt

--- a/tests/ometeotl_core/generation/test_rule_engine.py
+++ b/tests/ometeotl_core/generation/test_rule_engine.py
@@ -1,0 +1,331 @@
+"""Tests for the pluggable generation rule engine."""
+
+import pytest
+
+from ometeotl_core.generation import (
+    ContextualGenerationPipeline,
+    GenerationContext,
+    GenerationRule,
+    GenerationRuleSet,
+    RuleRegistry,
+    admissibility_constraint_rules,
+    combined_generation_rules,
+    default_generation_rules,
+    default_rule_registry,
+    spatial_constraint_rules,
+    temporal_constraint_rules,
+)
+from ometeotl_core.model.actors import Actor
+
+# ---------------------------------------------------------------------------
+# GenerationRule / GenerationRuleSet
+# ---------------------------------------------------------------------------
+
+
+def test_generation_rule_applies_when_predicate_is_true():
+    rule = GenerationRule(
+        name="tag_kind",
+        predicate=lambda ctx: ctx.kind == "actor",
+        apply=lambda ctx: ctx.copy_with(attributes={**ctx.attributes, "tagged": True}),
+    )
+    ctx = GenerationContext(kind="actor", id="a-1")
+    result = rule.run(ctx)
+    assert result.attributes.get("tagged") is True
+
+
+def test_generation_rule_skips_when_predicate_is_false():
+    rule = GenerationRule(
+        name="tag_kind",
+        predicate=lambda ctx: ctx.kind == "world",
+        apply=lambda ctx: ctx.copy_with(attributes={**ctx.attributes, "tagged": True}),
+    )
+    ctx = GenerationContext(kind="actor", id="a-2")
+    result = rule.run(ctx)
+    assert "tagged" not in result.attributes
+
+
+def test_rule_set_applies_rules_in_order():
+    calls: list[str] = []
+
+    def make_rule(tag: str) -> GenerationRule:
+        return GenerationRule(
+            name=f"rule_{tag}",
+            predicate=lambda ctx: True,
+            apply=lambda ctx, t=tag: (calls.append(t), ctx)[1],
+        )
+
+    rule_set = GenerationRuleSet([make_rule("A"), make_rule("B"), make_rule("C")])
+    rule_set.apply(GenerationContext(kind="actor", id="x"))
+    assert calls == ["A", "B", "C"]
+
+
+def test_rule_set_exposes_rule_names():
+    rule_set = combined_generation_rules()
+    names = [r.name for r in rule_set.rules]
+    assert "normalize_relations" in names
+    assert "promote_label" in names
+    assert "propagate_temporal_constraints" in names
+    assert "propagate_spatial_constraints" in names
+    assert "propagate_admissibility_constraints" in names
+
+
+# ---------------------------------------------------------------------------
+# RuleRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_rule_registry_register_and_get():
+    registry = RuleRegistry()
+    rule_set = default_generation_rules()
+    registry.register("my_rules", rule_set)
+    assert registry.exists("my_rules")
+    assert registry.get("my_rules") is rule_set
+
+
+def test_rule_registry_require_raises_on_unknown_name():
+    registry = RuleRegistry()
+    with pytest.raises(KeyError, match="Unknown generation rule set"):
+        registry.require("nonexistent")
+
+
+def test_rule_registry_register_rejects_empty_name():
+    registry = RuleRegistry()
+    with pytest.raises(ValueError, match="cannot be empty"):
+        registry.register("", default_generation_rules())
+
+
+def test_rule_registry_names_returns_sorted_list():
+    registry = RuleRegistry()
+    registry.register("zzz", default_generation_rules())
+    registry.register("aaa", temporal_constraint_rules())
+    assert registry.names() == ["aaa", "zzz"]
+
+
+def test_default_rule_registry_contains_all_built_in_rule_sets():
+    registry = default_rule_registry()
+    assert registry.names() == [
+        "admissibility",
+        "combined",
+        "default",
+        "spatial",
+        "temporal",
+    ]
+
+
+def test_default_rule_registry_each_built_in_is_a_rule_set():
+    registry = default_rule_registry()
+    for name in registry.names():
+        assert isinstance(registry.require(name), GenerationRuleSet)
+
+
+# ---------------------------------------------------------------------------
+# Temporal constraint propagation
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_constraint_rule_propagates_window_to_metadata():
+    rule_set = temporal_constraint_rules()
+    ctx = GenerationContext(
+        kind="goal",
+        id="goal-t-1",
+        constraints={"temporal": {"window": 10}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["horizon"]["window"] == 10
+
+
+def test_temporal_constraint_rule_propagates_start_step_to_metadata():
+    rule_set = temporal_constraint_rules()
+    ctx = GenerationContext(
+        kind="goal",
+        id="goal-t-2",
+        constraints={"temporal": {"start_step": 5}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["timeline"]["start_step"] == 5
+
+
+def test_temporal_constraint_rule_coerces_invalid_window_to_fallback():
+    rule_set = temporal_constraint_rules()
+    ctx = GenerationContext(
+        kind="goal",
+        id="goal-t-3",
+        constraints={"temporal": {"window": -99}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["horizon"]["window"] == 1
+
+
+def test_temporal_constraint_rule_skips_when_no_temporal_constraints():
+    rule_set = temporal_constraint_rules()
+    ctx = GenerationContext(kind="goal", id="goal-t-4")
+    result = rule_set.apply(ctx)
+    assert "horizon" not in result.metadata
+    assert "timeline" not in result.metadata
+
+
+def test_temporal_constraint_rule_does_not_overwrite_existing_metadata():
+    rule_set = temporal_constraint_rules()
+    ctx = GenerationContext(
+        kind="goal",
+        id="goal-t-5",
+        metadata={"horizon": {"window": 3}},
+        constraints={"temporal": {"window": 20}},
+    )
+    result = rule_set.apply(ctx)
+    # pre-existing value preserved (setdefault semantics)
+    assert result.metadata["horizon"]["window"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Spatial constraint propagation
+# ---------------------------------------------------------------------------
+
+
+def test_spatial_constraint_rule_propagates_allowed_spaces():
+    rule_set = spatial_constraint_rules()
+    ctx = GenerationContext(
+        kind="actor",
+        id="actor-s-1",
+        constraints={"spatial": {"allowed_spaces": ["zone-a", "zone-b"]}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["allowed_spaces"] == ["zone-a", "zone-b"]
+
+
+def test_spatial_constraint_rule_deduplicates_and_sorts_allowed_spaces():
+    rule_set = spatial_constraint_rules()
+    ctx = GenerationContext(
+        kind="actor",
+        id="actor-s-2",
+        constraints={"spatial": {"allowed_spaces": ["zone-b", "zone-a", "zone-b"]}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["allowed_spaces"] == ["zone-a", "zone-b"]
+
+
+def test_spatial_constraint_rule_propagates_required_space_to_space_id():
+    rule_set = spatial_constraint_rules()
+    ctx = GenerationContext(
+        kind="action",
+        id="action-s-1",
+        constraints={"spatial": {"required_space": "zone-c"}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["space_id"] == "zone-c"
+
+
+def test_spatial_constraint_rule_skips_when_no_spatial_constraints():
+    rule_set = spatial_constraint_rules()
+    ctx = GenerationContext(kind="actor", id="actor-s-3")
+    result = rule_set.apply(ctx)
+    assert "allowed_spaces" not in result.metadata
+    assert "space_id" not in result.metadata
+
+
+# ---------------------------------------------------------------------------
+# Admissibility constraint propagation
+# ---------------------------------------------------------------------------
+
+
+def test_admissibility_constraint_rule_propagates_required_capability():
+    rule_set = admissibility_constraint_rules()
+    ctx = GenerationContext(
+        kind="goal",
+        id="goal-a-1",
+        constraints={"admissibility": {"required_capability": "mobility"}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["required_capability"] == "mobility"
+
+
+def test_admissibility_constraint_rule_propagates_minimum_confidence():
+    rule_set = admissibility_constraint_rules()
+    ctx = GenerationContext(
+        kind="goal",
+        id="goal-a-2",
+        constraints={"admissibility": {"minimum_confidence": 0.8}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["minimum_confidence"] == pytest.approx(0.8)
+
+
+def test_admissibility_constraint_rule_clamps_confidence_above_one():
+    rule_set = admissibility_constraint_rules()
+    ctx = GenerationContext(
+        kind="goal",
+        id="goal-a-3",
+        constraints={"admissibility": {"minimum_confidence": 1.5}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["minimum_confidence"] == pytest.approx(1.0)
+
+
+def test_admissibility_constraint_rule_clamps_confidence_below_zero():
+    rule_set = admissibility_constraint_rules()
+    ctx = GenerationContext(
+        kind="goal",
+        id="goal-a-4",
+        constraints={"admissibility": {"minimum_confidence": -0.5}},
+    )
+    result = rule_set.apply(ctx)
+    assert result.metadata["minimum_confidence"] == pytest.approx(0.0)
+
+
+def test_admissibility_constraint_rule_skips_when_no_admissibility_constraints():
+    rule_set = admissibility_constraint_rules()
+    ctx = GenerationContext(kind="goal", id="goal-a-5")
+    result = rule_set.apply(ctx)
+    assert "required_capability" not in result.metadata
+    assert "minimum_confidence" not in result.metadata
+
+
+# ---------------------------------------------------------------------------
+# Combined rule set and pipeline integration
+# ---------------------------------------------------------------------------
+
+
+def test_combined_rules_apply_all_propagations_in_one_pass():
+    rule_set = combined_generation_rules()
+    ctx = GenerationContext(
+        kind="actor",
+        id="actor-c-1",
+        label="Combined Actor",
+        relations={"resource": ["res-1", "res-1"]},
+        constraints={
+            "temporal": {"window": 5},
+            "spatial": {"allowed_spaces": ["z1", "z2"]},
+            "admissibility": {"minimum_confidence": 0.7},
+        },
+    )
+    result = rule_set.apply(ctx)
+    assert result.attributes.get("label") == "Combined Actor"
+    assert result.relations["resource"] == ["res-1"]
+    assert result.metadata["horizon"]["window"] == 5
+    assert result.metadata["allowed_spaces"] == ["z1", "z2"]
+    assert result.metadata["minimum_confidence"] == pytest.approx(0.7)
+
+
+def test_pipeline_uses_combined_rules_and_propagates_spatial_constraint():
+    pipeline = ContextualGenerationPipeline()
+    ctx = GenerationContext(
+        kind="actor",
+        id="actor-pipe-1",
+        constraints={"spatial": {"allowed_spaces": ["zone-a", "zone-b"]}},
+    )
+    result = pipeline.generate(ctx)
+    assert isinstance(result.generated, Actor)
+    assert "propagate_spatial_constraints" in result.applied_rule_names
+
+
+def test_pipeline_accepts_custom_rule_set_from_registry():
+    registry = default_rule_registry()
+    pipeline = ContextualGenerationPipeline(rules=registry.require("temporal"))
+    ctx = GenerationContext(
+        kind="actor",
+        id="actor-pipe-2",
+        constraints={"temporal": {"window": 7}},
+    )
+    result = pipeline.generate(ctx)
+    assert isinstance(result.generated, Actor)
+    assert "propagate_temporal_constraints" in result.applied_rule_names

--- a/tests/ometeotl_core/io/test_world_io.py
+++ b/tests/ometeotl_core/io/test_world_io.py
@@ -5,6 +5,11 @@ import json
 import pytest
 import yaml
 
+from tests.ometeotl_core._artifact_utils import (
+    write_json_artifact,
+    write_text_artifact,
+)
+
 from ometeotl_core.io import (
     world_to_llm_view,
     world_from_json,
@@ -142,27 +147,28 @@ def test_world_to_json_is_deterministic():
     assert first == second
     assert json.loads(first)["id"] == "world-io-1"
 
+    artifact_path = write_text_artifact(
+        layer="io/world_export/json",
+        name="world_to_json_deterministic",
+        content=first,
+        extension="json",
+    )
+    assert artifact_path.name == "world_to_json_deterministic.json"
+
 
 def test_world_json_roundtrip_preserves_graph_and_registry():
     """JSON import/export should preserve world structure and registered types."""
     world = _build_world()
+    json_text = world_to_json(world)
 
-    result = world_from_json(world_to_json(world))
+    result = world_from_json(json_text)
 
     assert result.parsed_format == "json"
     assert result.validation.valid is True
     assert result.world.id == world.id
     assert result.world.get_space("zone-a") is not None
-    assert (
-        "actor-1"
-        in result.world.space_object_graph.list_objects_in_space(
-            "zone-a"
-        )
-    )
-    assert (
-        result.world.model_registry.get("actor-registered")
-        is not None
-    )
+    assert "actor-1" in result.world.space_object_graph.list_objects_in_space("zone-a")
+    assert result.world.model_registry.get("actor-registered") is not None
     assert isinstance(
         result.world.model_registry.get("actor-registered"),
         Actor,
@@ -171,6 +177,14 @@ def test_world_json_roundtrip_preserves_graph_and_registry():
         result.world.model_registry.get("resource-registered"),
         Resource,
     )
+
+    artifact_path = write_text_artifact(
+        layer="io/world_export/json",
+        name="world_json_roundtrip",
+        content=json_text,
+        extension="json",
+    )
+    assert artifact_path.name == "world_json_roundtrip.json"
 
 
 def test_world_yaml_roundtrip_preserves_canonical_payload():
@@ -184,6 +198,14 @@ def test_world_yaml_roundtrip_preserves_canonical_payload():
     assert yaml.safe_load(yaml_text) == world.to_dict()
     assert result.world.to_dict() == world.to_dict()
 
+    artifact_path = write_text_artifact(
+        layer="io/world_export/yaml",
+        name="world_yaml_roundtrip",
+        content=yaml_text,
+        extension="yaml",
+    )
+    assert artifact_path.name == "world_yaml_roundtrip.yaml"
+
 
 def test_world_from_json_rejects_invalid_payload():
     """Invalid JSON should fail before reconstruction."""
@@ -194,9 +216,7 @@ def test_world_from_json_rejects_invalid_payload():
 def test_world_from_mapping_raises_validation_exception_for_structural_errors():
     """Structurally invalid mappings should be rejected explicitly."""
     with pytest.raises(ValidationException) as exc_info:
-        world_from_mapping(
-            {"id": "broken-world", "relations": []}
-        )
+        world_from_mapping({"id": "broken-world", "relations": []})
 
     assert exc_info.value.result.valid is False
     assert exc_info.value.result.summary["error"] >= 1
@@ -210,34 +230,22 @@ def test_world_from_json_aggregates_all_stage_issues_before_raising():
     stages. Before the fix, the first failing stage raised early and the aggregated
     result was never returned to the caller.
     """
-    structurally_invalid_json = (
-        '{"id": "broken-world", "relations": []}'
-    )
+    structurally_invalid_json = '{"id": "broken-world", "relations": []}'
     with pytest.raises(ValidationException) as exc_info:
-        world_from_json(
-            structurally_invalid_json, raise_on_error=True
-        )
+        world_from_json(structurally_invalid_json, raise_on_error=True)
 
     result = exc_info.value.result
     assert result.valid is False
     executed = result.metadata["executed_validators"]
-    assert (
-        "syntactic" in executed
-    ), "Syntactic stage must have run"
-    assert (
-        "structural" in executed
-    ), "Structural stage must have run"
+    assert "syntactic" in executed, "Syntactic stage must have run"
+    assert "structural" in executed, "Structural stage must have run"
     assert result.summary["error"] >= 1
 
 
 def test_world_from_json_returns_result_without_raising_when_raise_on_error_false():
     """raise_on_error=False must suppress ValidationException and return the result."""
-    structurally_invalid_json = (
-        '{"id": "broken-world", "relations": []}'
-    )
-    result = world_from_json(
-        structurally_invalid_json, raise_on_error=False
-    )
+    structurally_invalid_json = '{"id": "broken-world", "relations": []}'
+    result = world_from_json(structurally_invalid_json, raise_on_error=False)
     assert result.validation.valid is False
     assert result.validation.summary["error"] >= 1
 
@@ -264,9 +272,7 @@ def test_world_from_mapping_skips_syntactic_subclass_validator():
             raise_on_error=True,
         )
 
-    executed = exc_info.value.result.metadata[
-        "executed_validators"
-    ]
+    executed = exc_info.value.result.metadata["executed_validators"]
     assert "syntactic_custom" not in executed
     assert "structural" in executed
 
@@ -275,10 +281,27 @@ def test_world_json_and_yaml_exports_describe_same_payload():
     """JSON and YAML exports should encode the same canonical mapping."""
     world = _build_world()
 
-    json_payload = json.loads(world_to_json(world))
-    yaml_payload = yaml.safe_load(world_to_yaml(world))
+    json_text = world_to_json(world)
+    yaml_text = world_to_yaml(world)
+    json_payload = json.loads(json_text)
+    yaml_payload = yaml.safe_load(yaml_text)
 
     assert json_payload == yaml_payload == world.to_dict()
+
+    json_artifact = write_text_artifact(
+        layer="io/world_export/json",
+        name="world_export_payload_equivalence",
+        content=json_text,
+        extension="json",
+    )
+    yaml_artifact = write_text_artifact(
+        layer="io/world_export/yaml",
+        name="world_export_payload_equivalence",
+        content=yaml_text,
+        extension="yaml",
+    )
+    assert json_artifact.name == "world_export_payload_equivalence.json"
+    assert yaml_artifact.name == "world_export_payload_equivalence.yaml"
 
 
 def test_world_to_llm_view_summarizes_registry_members_without_error():
@@ -300,6 +323,13 @@ def test_world_to_llm_view_summarizes_registry_members_without_error():
         "resources": ["resource-registered"],
     }
 
+    artifact_path = write_json_artifact(
+        layer="io/llm_export",
+        name="world_llm_view_members_summary",
+        payload=view,
+    )
+    assert artifact_path.name == "world_llm_view_members_summary.json"
+
 
 def test_world_to_llm_view_sorts_member_ids_deterministically():
     """LLM export must sort registry member IDs regardless of registration order."""
@@ -316,6 +346,13 @@ def test_world_to_llm_view_sorts_member_ids_deterministically():
     assert view["members"]["actors"] == ["actor-a", "actor-z"]
     assert view["members"]["resources"] == ["resource-a", "resource-z"]
     assert view["members"]["spaces"] == ["space-a", "space-z"]
+
+    artifact_path = write_json_artifact(
+        layer="io/llm_export",
+        name="world_llm_view_sorted_members",
+        payload=view,
+    )
+    assert artifact_path.name == "world_llm_view_sorted_members.json"
 
 
 def test_model_objects_expose_to_llm_view_directly():
@@ -359,11 +396,17 @@ def test_strategy_goal_and_perception_expose_direct_llm_views():
 
     assert perception_view["type"] == "perception"
     assert perception_view["reality"]["actor_id"] == "actor-1"
-    assert perception_view["perception"]["perceived_spaces"]["zone-a"]["epistemic_status"] == "certain"
+    assert (
+        perception_view["perception"]["perceived_spaces"]["zone-a"]["epistemic_status"]
+        == "certain"
+    )
     assert perception_view["epistemic_statuses"]["certain"][0]["kind"] == "space"
     assert perception_view["epistemic_statuses"]["believed"][0]["kind"] == "membership"
     assert perception_view["epistemic_statuses"]["hypothesis"][0]["kind"] == "relation"
-    assert perception_view["epistemic_statuses"]["projected"][0]["kind"] == "component_link"
+    assert (
+        perception_view["epistemic_statuses"]["projected"][0]["kind"]
+        == "component_link"
+    )
     assert perception_view["epistemic"]["has_perception"] is True
 
 
@@ -374,8 +417,12 @@ def test_perception_llm_view_is_stable_across_insertion_order():
         actor_id="actor-1",
         source_id="world-1",
         perceived_spaces={
-            "zone-b": PerceivedSpace(space=Space(id="zone-b"), epistemic_status="certain"),
-            "zone-a": PerceivedSpace(space=Space(id="zone-a"), epistemic_status="certain"),
+            "zone-b": PerceivedSpace(
+                space=Space(id="zone-b"), epistemic_status="certain"
+            ),
+            "zone-a": PerceivedSpace(
+                space=Space(id="zone-a"), epistemic_status="certain"
+            ),
         },
         perceived_memberships=[
             PerceivedMembership(
@@ -434,8 +481,12 @@ def test_perception_llm_view_is_stable_across_insertion_order():
         actor_id="actor-1",
         source_id="world-1",
         perceived_spaces={
-            "zone-a": PerceivedSpace(space=Space(id="zone-a"), epistemic_status="certain"),
-            "zone-b": PerceivedSpace(space=Space(id="zone-b"), epistemic_status="certain"),
+            "zone-a": PerceivedSpace(
+                space=Space(id="zone-a"), epistemic_status="certain"
+            ),
+            "zone-b": PerceivedSpace(
+                space=Space(id="zone-b"), epistemic_status="certain"
+            ),
         },
         perceived_memberships=[
             PerceivedMembership(
@@ -543,3 +594,25 @@ def test_action_and_generic_model_object_expose_direct_llm_views():
     assert generic_view["reality"]["attributes"]["label"] == "Generic Object"
     assert generic_view["perception"] is None
     assert generic_view["epistemic"]["status"] == "certain"
+
+
+def test_llm_export_audit_writes_local_lab_artifact():
+    """Write a stable LLM export snapshot under local_lab for audit review."""
+    world = _build_world()
+    strategy = _build_strategy()
+    goal = _build_goal()
+    perception = _build_perception()
+
+    payload = {
+        "world": world.to_llm_view(),
+        "strategy": strategy.to_llm_view(),
+        "goal": goal.to_llm_view(),
+        "perception": perception.to_llm_view(),
+    }
+    artifact_path = write_json_artifact(
+        layer="io/llm_export",
+        name="llm_export_snapshot",
+        payload=payload,
+    )
+
+    assert artifact_path.name == "llm_export_snapshot.json"

--- a/tests/ometeotl_core/model/test_actors.py
+++ b/tests/ometeotl_core/model/test_actors.py
@@ -295,3 +295,31 @@ def test_actor_from_context_builds_actor_with_structural_validation():
 def test_actor_from_context_requires_non_empty_id():
     with pytest.raises(ValueError, match="requires non-empty 'id'"):
         Actor.from_context({"attributes": {"energy": 2}})
+
+
+def test_actor_from_context_forwards_validate_flag(monkeypatch):
+    import ometeotl_core.generation as generation_module
+
+    class _DummyPipeline:
+        def __init__(self, *, validation_pipeline):
+            del validation_pipeline
+
+        def generate(self, generation_context):
+            assert generation_context.validate is False
+
+            class _Result:
+                generated = Actor(id="actor-ctx-forward-1")
+                validation = None
+
+            return _Result()
+
+    monkeypatch.setattr(
+        generation_module,
+        "ContextualGenerationPipeline",
+        _DummyPipeline,
+    )
+
+    actor = Actor.from_context({"id": "actor-ctx-forward-1", "validate": False})
+
+    assert isinstance(actor, Actor)
+    assert actor.id == "actor-ctx-forward-1"

--- a/tests/ometeotl_core/model/test_actors.py
+++ b/tests/ometeotl_core/model/test_actors.py
@@ -33,9 +33,7 @@ def test_actor_add_role_and_tag():
 
 def test_actor_from_dict_null_optional_maps_defaults_empty():
     """Actor should accept null optional maps in from_dict."""
-    actor = Actor.from_dict(
-        {"id": "a-null", "attributes": None, "relations": None}
-    )
+    actor = Actor.from_dict({"id": "a-null", "attributes": None, "relations": None})
 
     assert isinstance(actor.attributes, dict)
     assert actor.relations == {}
@@ -271,3 +269,29 @@ def test_actor_serialization_round_trip_with_components():
     restored = Actor.from_dict(actor.to_dict())
     assert restored.composition_mode == "composite"
     assert sorted(restored.get_components()) == ["a-2", "a-3"]
+
+
+def test_actor_from_context_builds_actor_with_structural_validation():
+    actor = Actor.from_context(
+        {
+            "id": "actor-ctx-1",
+            "label": "Actor from context",
+            "attributes": {
+                "energy": 10,
+                "composition_mode": "composite",
+            },
+            "relations": {"component": ["actor-ctx-2"]},
+            "validate": False,
+        }
+    )
+
+    assert isinstance(actor, Actor)
+    assert actor.id == "actor-ctx-1"
+    assert actor.label == "Actor from context"
+    assert actor.composition_mode == "composite"
+    assert actor.get_components() == ["actor-ctx-2"]
+
+
+def test_actor_from_context_requires_non_empty_id():
+    with pytest.raises(ValueError, match="requires non-empty 'id'"):
+        Actor.from_context({"attributes": {"energy": 2}})

--- a/tests/ometeotl_core/model/test_goals.py
+++ b/tests/ometeotl_core/model/test_goals.py
@@ -563,3 +563,31 @@ def test_goal_build_step_validation():
             target_condition={},
             priority=1.5,
         )
+
+
+def test_goal_from_context_builds_goal_with_structural_validation():
+    goal = Goal.from_context(
+        {
+            "id": "goal-ctx-1",
+            "actor_id": "actor-ctx-1",
+            "kind": "intermediate",
+            "priority": 0.5,
+            "status": "active",
+            "target_condition": {"wealth": 100},
+            "horizon": {"max_steps": 8},
+            "validate": False,
+        }
+    )
+
+    assert isinstance(goal, Goal)
+    assert goal.id == "goal-ctx-1"
+    assert goal.actor_id == "actor-ctx-1"
+    assert goal.kind == "intermediate"
+    assert goal.priority == 0.5
+    assert goal.target_condition == {"wealth": 100}
+    assert goal.horizon == {"max_steps": 8}
+
+
+def test_goal_from_context_requires_non_empty_id():
+    with pytest.raises(ValueError, match="requires non-empty 'id'"):
+        Goal.from_context({"actor_id": "actor-1"})

--- a/tests/ometeotl_core/model/test_goals.py
+++ b/tests/ometeotl_core/model/test_goals.py
@@ -591,3 +591,44 @@ def test_goal_from_context_builds_goal_with_structural_validation():
 def test_goal_from_context_requires_non_empty_id():
     with pytest.raises(ValueError, match="requires non-empty 'id'"):
         Goal.from_context({"actor_id": "actor-1"})
+
+
+def test_goal_from_context_forwards_validate_flag(monkeypatch):
+    import ometeotl_core.generation as generation_module
+
+    class _DummyPipeline:
+        def __init__(self, *, validation_pipeline):
+            del validation_pipeline
+
+        def generate(self, generation_context):
+            assert generation_context.validate is False
+
+            class _Result:
+                generated = Goal(
+                    id="goal-ctx-forward-1",
+                    actor_id="actor-1",
+                    kind="final",
+                    target_condition={},
+                )
+                validation = None
+
+            return _Result()
+
+    monkeypatch.setattr(
+        generation_module,
+        "ContextualGenerationPipeline",
+        _DummyPipeline,
+    )
+
+    goal = Goal.from_context(
+        {
+            "id": "goal-ctx-forward-1",
+            "actor_id": "actor-1",
+            "kind": "final",
+            "target_condition": {},
+            "validate": False,
+        }
+    )
+
+    assert isinstance(goal, Goal)
+    assert goal.id == "goal-ctx-forward-1"

--- a/tests/ometeotl_core/model/test_strategies.py
+++ b/tests/ometeotl_core/model/test_strategies.py
@@ -526,3 +526,43 @@ def test_strategy_from_context_builds_strategy_with_structural_validation():
 def test_strategy_from_context_requires_non_empty_id():
     with pytest.raises(ValueError, match="requires non-empty 'id'"):
         Strategy.from_context({"actor_id": "actor-1"})
+
+
+def test_strategy_from_context_forwards_validate_flag(monkeypatch):
+    import ometeotl_core.generation as generation_module
+
+    class _DummyPipeline:
+        def __init__(self, *, validation_pipeline):
+            del validation_pipeline
+
+        def generate(self, generation_context):
+            assert generation_context.validate is False
+
+            class _Result:
+                generated = Strategy(
+                    id="strategy-ctx-forward-1",
+                    actor_id="actor-1",
+                    root_node_id="root",
+                    nodes=[StrategyNode(node_id="root", action_id="action-1")],
+                )
+                validation = None
+
+            return _Result()
+
+    monkeypatch.setattr(
+        generation_module,
+        "ContextualGenerationPipeline",
+        _DummyPipeline,
+    )
+
+    strategy = Strategy.from_context(
+        {
+            "id": "strategy-ctx-forward-1",
+            "actor_id": "actor-1",
+            "action_id": "action-1",
+            "validate": False,
+        }
+    )
+
+    assert isinstance(strategy, Strategy)
+    assert strategy.id == "strategy-ctx-forward-1"

--- a/tests/ometeotl_core/model/test_strategies.py
+++ b/tests/ometeotl_core/model/test_strategies.py
@@ -58,10 +58,7 @@ def test_strategy_instantiation():
     assert strategy.root_node_id == "node-root"
     assert strategy.projection_policy == "perception_first"
     assert len(strategy.nodes) == 1
-    assert (
-        strategy.nodes[0].source_perception_id
-        == "perception-root"
-    )
+    assert strategy.nodes[0].source_perception_id == "perception-root"
     assert (
         strategy.nodes[0].successor_perception_id
         == "projection-perception-root-action-1"
@@ -125,19 +122,13 @@ def test_strategy_serialization_is_deterministic():
         "node-b",
     ]
     assert payload["goal_id"] is None
+    assert payload["nodes"][0]["source_perception_id"] == "perception-chain-root"
     assert (
-        payload["nodes"][0]["source_perception_id"]
-        == "perception-chain-root"
-    )
-    assert (
-        payload["nodes"][0]["projected_state"]["perception"][
-            "id"
-        ]
+        payload["nodes"][0]["projected_state"]["perception"]["id"]
         == "projection-perception-chain-root-action-1"
     )
     assert [
-        branch["branch_id"]
-        for branch in payload["nodes"][1]["outcome_branches"]
+        branch["branch_id"] for branch in payload["nodes"][1]["outcome_branches"]
     ] == ["a", "z"]
     assert restored.to_dict() == payload
 
@@ -351,10 +342,7 @@ def test_build_linear_strategy_chains_nodes_from_ordered_actions_sequence():
         "node-0001-action-build-1",
         "node-0002-action-build-2",
     ]
-    assert (
-        strategy.nodes[0].source_perception_id
-        == "perception-build-root"
-    )
+    assert strategy.nodes[0].source_perception_id == "perception-build-root"
     assert (
         strategy.nodes[1].source_perception_id
         == strategy.nodes[0].successor_perception_id
@@ -364,12 +352,7 @@ def test_build_linear_strategy_chains_nodes_from_ordered_actions_sequence():
         == "node-0002-action-build-2"
     )
     assert strategy.nodes[1].projected_state is not None
-    assert (
-        strategy.nodes[1].projected_state.perception.context[
-            "step"
-        ]
-        == 2
-    )
+    assert strategy.nodes[1].projected_state.perception.context["step"] == 2
 
 
 def test_build_linear_strategy_rejects_empty_action_sequence():
@@ -427,9 +410,7 @@ def test_build_branching_strategy_creates_tree_from_recursive_steps():
                 world_id="world-1",
                 space_id="space-1",
                 action_type="plan",
-                state_changes={
-                    "context_updates": {"phase": "root"}
-                },
+                state_changes={"context_updates": {"phase": "root"}},
             ),
             children=[
                 StrategyBuildStep(
@@ -439,9 +420,7 @@ def test_build_branching_strategy_creates_tree_from_recursive_steps():
                         world_id="world-1",
                         space_id="space-1",
                         action_type="explore",
-                        state_changes={
-                            "context_updates": {"phase": "left"}
-                        },
+                        state_changes={"context_updates": {"phase": "left"}},
                     ),
                     branch_label="left",
                     branch_probability=0.4,
@@ -454,9 +433,7 @@ def test_build_branching_strategy_creates_tree_from_recursive_steps():
                         world_id="world-1",
                         space_id="space-1",
                         action_type="secure",
-                        state_changes={
-                            "context_updates": {"phase": "right"}
-                        },
+                        state_changes={"context_updates": {"phase": "right"}},
                     ),
                     branch_label="right",
                     branch_probability=0.6,
@@ -467,41 +444,23 @@ def test_build_branching_strategy_creates_tree_from_recursive_steps():
     )
 
     root_node = strategy.get_node("node-0001-action-root-branch")
-    left_node = strategy.get_node(
-        "node-0001-0001-action-left-branch"
-    )
-    right_node = strategy.get_node(
-        "node-0001-0002-action-right-branch"
-    )
+    left_node = strategy.get_node("node-0001-0001-action-left-branch")
+    right_node = strategy.get_node("node-0001-0002-action-right-branch")
 
     assert root_node is not None
     assert left_node is not None
     assert right_node is not None
     assert len(root_node.outcome_branches) == 2
-    assert [
-        branch.label for branch in root_node.outcome_branches
-    ] == [
+    assert [branch.label for branch in root_node.outcome_branches] == [
         "left",
         "right",
     ]
-    assert (
-        left_node.source_perception_id
-        == root_node.successor_perception_id
-    )
-    assert (
-        right_node.source_perception_id
-        == root_node.successor_perception_id
-    )
+    assert left_node.source_perception_id == root_node.successor_perception_id
+    assert right_node.source_perception_id == root_node.successor_perception_id
     assert left_node.projected_state is not None
     assert right_node.projected_state is not None
-    assert (
-        left_node.projected_state.perception.context["phase"]
-        == "left"
-    )
-    assert (
-        right_node.projected_state.perception.context["phase"]
-        == "right"
-    )
+    assert left_node.projected_state.perception.context["phase"] == "left"
+    assert right_node.projected_state.perception.context["phase"] == "right"
 
 
 def test_build_branching_strategy_rejects_blocked_child_step():
@@ -539,3 +498,31 @@ def test_build_branching_strategy_rejects_blocked_child_step():
                 ],
             ),
         )
+
+
+def test_strategy_from_context_builds_strategy_with_structural_validation():
+    strategy = Strategy.from_context(
+        {
+            "id": "strategy-ctx-1",
+            "actor_id": "actor-ctx-1",
+            "goal_id": "goal-ctx-1",
+            "root_node_id": "node-root-ctx",
+            "action_id": "action-ctx-1",
+            "projection_policy": "perception_first",
+            "validate": False,
+        }
+    )
+
+    assert isinstance(strategy, Strategy)
+    assert strategy.id == "strategy-ctx-1"
+    assert strategy.actor_id == "actor-ctx-1"
+    assert strategy.goal_id == "goal-ctx-1"
+    assert strategy.root_node_id == "node-root-ctx"
+    assert strategy.projection_policy == "perception_first"
+    assert len(strategy.nodes) == 1
+    assert strategy.nodes[0].node_id == "node-root-ctx"
+
+
+def test_strategy_from_context_requires_non_empty_id():
+    with pytest.raises(ValueError, match="requires non-empty 'id'"):
+        Strategy.from_context({"actor_id": "actor-1"})

--- a/tests/ometeotl_core/model/test_world.py
+++ b/tests/ometeotl_core/model/test_world.py
@@ -285,6 +285,34 @@ def test_world_from_context_requires_non_empty_id():
         World.from_context({"spaces": [{"id": "s1", "kind": "space"}]})
 
 
+def test_world_from_context_rejects_empty_placement_object_id():
+    with pytest.raises(
+        ValueError,
+        match="placements require non-empty 'object_id' and 'space_id'",
+    ):
+        World.from_context(
+            {
+                "id": "world-invalid-placement-1",
+                "placements": [{"object_id": "", "space_id": "space-1"}],
+                "validate": False,
+            }
+        )
+
+
+def test_world_from_context_rejects_empty_placement_space_id():
+    with pytest.raises(
+        ValueError,
+        match="placements require non-empty 'object_id' and 'space_id'",
+    ):
+        World.from_context(
+            {
+                "id": "world-invalid-placement-2",
+                "placements": [{"object_id": "actor-1", "space_id": ""}],
+                "validate": False,
+            }
+        )
+
+
 def test_world_from_context_forwards_validate_flag(monkeypatch):
     import ometeotl_core.generation as generation_module
 

--- a/tests/ometeotl_core/model/test_world.py
+++ b/tests/ometeotl_core/model/test_world.py
@@ -283,3 +283,31 @@ def test_world_from_context_builds_nested_world_with_structural_validation():
 def test_world_from_context_requires_non_empty_id():
     with pytest.raises(ValueError, match="requires non-empty 'id'"):
         World.from_context({"spaces": [{"id": "s1", "kind": "space"}]})
+
+
+def test_world_from_context_forwards_validate_flag(monkeypatch):
+    import ometeotl_core.generation as generation_module
+
+    class _DummyPipeline:
+        def __init__(self, *, validation_pipeline):
+            del validation_pipeline
+
+        def generate(self, generation_context):
+            assert generation_context.validate is False
+
+            class _Result:
+                generated = World(id="world-ctx-forward-1")
+                validation = None
+
+            return _Result()
+
+    monkeypatch.setattr(
+        generation_module,
+        "ContextualGenerationPipeline",
+        _DummyPipeline,
+    )
+
+    world = World.from_context({"id": "world-ctx-forward-1", "validate": False})
+
+    assert isinstance(world, World)
+    assert world.id == "world-ctx-forward-1"

--- a/tests/ometeotl_core/model/test_world.py
+++ b/tests/ometeotl_core/model/test_world.py
@@ -48,9 +48,7 @@ def test_world_place_object_in_subspace():
     world.add_space(sub)
     world.place_object("actor-1", "zone-b", role="occupies")
 
-    members = world.space_object_graph.list_objects_in_space(
-        "zone-b"
-    )
+    members = world.space_object_graph.list_objects_in_space("zone-b")
     assert "actor-1" in members
 
 
@@ -104,16 +102,12 @@ def test_object_register_and_place():
     world.add_space(space)
     actor = Actor(id="test-actor")
 
-    world.add_object_to_space(
-        actor, "test-space", role="occupies"
-    )
+    world.add_object_to_space(actor, "test-space", role="occupies")
 
     # Check registration
     assert world.model_registry.exists("test-actor")
     # Check placement
-    members = world.space_object_graph.list_objects_in_space(
-        "test-space"
-    )
+    members = world.space_object_graph.list_objects_in_space("test-space")
     assert "test-actor" in members
 
 
@@ -164,15 +158,8 @@ def test_world_to_dict_roundtrip():
     assert restored.label == "Test World"
     assert restored.get_space("s1") is not None
     assert restored.get_space("s2") is not None
-    assert (
-        "actor-x"
-        in restored.space_object_graph.list_objects_in_space(
-            "s1"
-        )
-    )
-    assert "s2" in restored.space_relation_graph.neighbors_of(
-        "s1"
-    )
+    assert "actor-x" in restored.space_object_graph.list_objects_in_space("s1")
+    assert "s2" in restored.space_relation_graph.neighbors_of("s1")
 
 
 def test_world_spaces_where_object_exists():
@@ -183,9 +170,7 @@ def test_world_spaces_where_object_exists():
     world.place_object("actor-multi", "phys")
     world.place_object("actor-multi", "info")
 
-    spaces = world.space_object_graph.spaces_where_object_exists(
-        "actor-multi"
-    )
+    spaces = world.space_object_graph.spaces_where_object_exists("actor-multi")
     space_ids = [space.id for space in spaces]
     assert "phys" in space_ids
     assert "info" in space_ids
@@ -205,9 +190,7 @@ def test_world_to_dict_roundtrip_preserves_registered_objects():
     restored = World.from_dict(world.to_dict())
 
     restored_actor = restored.model_registry.get("actor-rt-1")
-    restored_resource = restored.model_registry.get(
-        "resource-rt-1"
-    )
+    restored_resource = restored.model_registry.get("resource-rt-1")
 
     assert isinstance(restored_actor, Actor)
     assert isinstance(restored_resource, Resource)
@@ -246,3 +229,57 @@ def test_world_from_dict_null_optional_maps_defaults_empty():
     assert world.provenance == {}
     assert world.space_object_graph.spaces == {}
     assert world.space_relation_graph.relations == []
+
+
+def test_world_from_context_builds_nested_world_with_structural_validation():
+    world = World.from_context(
+        {
+            "id": "world-ctx-1",
+            "label": "World from context",
+            "spaces": [
+                {
+                    "id": "space-ctx-1",
+                    "kind": "space",
+                    "label": "Zone 1",
+                    "attributes": {"is_abstract": False},
+                }
+            ],
+            "actors": [
+                {
+                    "id": "actor-ctx-10",
+                    "kind": "actor",
+                    "attributes": {"composition_mode": "standalone"},
+                }
+            ],
+            "resources": [
+                {
+                    "id": "resource-ctx-10",
+                    "kind": "resource",
+                    "attributes": {"kind": "material"},
+                }
+            ],
+            "placements": [
+                {
+                    "object_id": "actor-ctx-10",
+                    "space_id": "space-ctx-1",
+                    "role": "occupies",
+                }
+            ],
+            "validate": False,
+        }
+    )
+
+    assert isinstance(world, World)
+    assert world.id == "world-ctx-1"
+    assert world.label == "World from context"
+    assert world.get_space("space-ctx-1") is not None
+    assert world.model_registry.exists("actor-ctx-10")
+    assert world.model_registry.exists("resource-ctx-10")
+    assert "actor-ctx-10" in world.space_object_graph.list_objects_in_space(
+        "space-ctx-1"
+    )
+
+
+def test_world_from_context_requires_non_empty_id():
+    with pytest.raises(ValueError, match="requires non-empty 'id'"):
+        World.from_context({"spaces": [{"id": "s1", "kind": "space"}]})


### PR DESCRIPTION
## Why

The core model layer was complete but had no mechanism to export worlds to consumable formats, import them back, expose an LLM-readable epistemic view, or construct model objects from a declarative context. Two full layers were missing from the V1 chain defined by specs_EN.md: canonical IO and contextual generation.

---

## Link to SPEC

- **F-1 → F-8**: Canonical serialization, JSON/YAML format, cross-reference handling, determinism, schema versioning — implemented by `io/exporters.py` and `io/importers.py`.
- **F-5**: LLM/SLM view with explicit reality/perception/belief/hypothesis/projection separation — implemented by `io/llm_export.py` and `ModelObject.to_llm_view()`.
- **F-16 → F-22**: Contextual construction, `from_context` protocol, generation pipeline, partial/incremental generation, explicit uncertainty zones, hybrid symbolic+LLM generation, repair suggestions — implemented by the entire `generation/` layer.
- **F-26**: `LLMExportable` and `ContextualBuildable` interfaces — fulfilled by `model/interfaces.py` and wired through all concrete classes.
- **F-34 / F-35**: V1 must prove the full chain representation → validation → export → generation → game. Both layers close that chain.

---

## Architectural impact

**Layers modified:** `ometeotl_core/io/` (new), `ometeotl_core/generation/` (new), `ometeotl_core/model/interfaces.py` (extended), `World`, `Actor`, `Strategy`, `Goal` (new `from_context()` classmethods).

**Consistency with specs_EN.md:**
- IO lives entirely in `ometeotl_core/io/`, not in `model/`. Domain behavior (validation, epistemic separation) remains in `model/` and `validation/`; `io/` only orchestrates serialization and formatting — consistent with the layer separation mandate.
- Generation lives in `ometeotl_core/generation/`. It calls into `model/` constructors and `validation/` pipelines but adds no domain logic of its own. `from_context()` classmethods on model objects are the only surface that crosses the generation→model boundary, and they are declared as part of the `ContextualBuildable` interface in `model/interfaces.py`.
- `LLMGenerationAdapter` is a pure optional shim — it wraps an external provider call and falls back gracefully. No provider dependency is leaked into `generation/` or `model/`.

---

## What changed

**io (new)**
- `exporters.py`: `world_to_json`, `world_to_yaml`, `write_world_json`, `write_world_yaml` — deterministic, diffable, cross-reference-safe canonical export.
- `importers.py`: `world_from_json`, `world_from_yaml`, `WorldImportResult` — validated round-trip import with structured error reporting.
- `llm_export.py`: `LLMViewBuilder`, `world_to_llm_view`, `actor_to_llm_view`, `perception_to_llm_view` — LLM-oriented view with explicit epistemic layers (reality / perception / belief / hypothesis / projection). `ModelObject.to_llm_view()` wired on all core entities.

**generation (new)**
- `context.py`: `GenerationContext` declarative dataclass — nested child contexts, `GenerationPlacement` for space assignment, constraint declarations, `copy_with` for rule-safe immutable mutation.
- `context_builder.py`: `ContextualBuilder` ABC + five concrete builders (`WorldContextualBuilder`, `ActorContextualBuilder`, `StrategyContextualBuilder`, `GoalContextualBuilder`, `PerceptionContextualBuilder`).
- `rule_engine.py`: `GenerationRule`, `GenerationRuleSet`, `RuleRegistry` — pluggable rule engine. Five built-in rules: `normalize_relations`, `promote_label`, `propagate_temporal_constraints`, `propagate_spatial_constraints`, `propagate_admissibility_constraints`. `default_rule_registry()` pre-populated with `"default"`, `"temporal"`, `"spatial"`, `"admissibility"`, `"combined"`.
- `llm_integration.py`: `LLMGenerationAdapter` — provider-agnostic async-capable adapter with sync fallback; used optionally by the pipeline to refine a `GenerationContext` before rule application.
- `pipeline.py`: `ContextualGenerationPipeline` orchestrating rules → build → optional registry insertion → optional validation → `GenerationResult`. `GenerationResult` carries `generated`, `applied_rule_names`, `validation`, `diagnostics`, `uncertainty_zones`, `repair_suggestions`.
- `builders.py`: lower-level build helpers used internally by context builders.
- `rules.py`: backward-compatibility re-export shim.
- `examples.py`: four runnable demo scenarios (`demo_simple_world`, `demo_multi_actor_world`, `demo_perception_generation`, `demo_goal_generation`) and a `run_all()` entry point.

**model (extended)**
- `interfaces.py`: `LLMExportable` and `ContextualBuildable` added.
- `World`, `Actor`, `Strategy`, `Goal`: `from_context(ctx: GenerationContext)` classmethods.

**ometeotl_core (new)**
- `io/`: IO layer tests.
- `generation/test_context_builder.py`, `test_rule_engine.py`, `test_context_pipeline.py`, `test_llm_integration.py`: 58 new tests, all passing.

**Total test count: 317 → 396.**

---

## Risks

| Risk | Assessment |
|---|---|
| **Backward compatibility** | No existing public API was removed or renamed. `rules.py` is a compatibility shim for any prior import of generation rules. `from_context()` is additive. `to_llm_view()` is additive. Low risk. |
| **Edge cases** | `world_from_json` / `world_from_yaml` rely on the registry reconstruction path. A world exported before `interfaces.py` was added will lack `schema_version` — `WorldImportResult` surfaces this as a structured error rather than a crash. Malformed context with missing `object_id` handled by `ContextualBuilder` with explicit `ValueError`. |
| **Performance** | `combined_generation_rules()` runs all five rules sequentially on each context. For large deeply-nested `GenerationContext` trees the temporal and spatial propagation rules are O(n) in child count — acceptable for typical generation workloads; would need benchmarking before use in hot paths. |
| **Concurrency** | `RuleRegistry` is shared mutable state. If `register()` is called concurrently with `get()` in a multi-threaded pipeline, a race exists. Currently no locking — safe only for single-threaded or read-after-write-once usage. |

---

## What to review carefully

- **`ContextualGenerationPipeline.run()`**: the `copy_with` contract assumes rules never mutate the original context. Review that all five built-in rules call `copy_with` and never assign to `ctx` fields directly.
- **`world_from_json` / `world_from_yaml`**: the reconstruction path through `WorldModelRegistry` must re-attach `SpaceObjectGraph` edges and `SpaceRelationGraph` entries in the correct order. A partial import (e.g., a space referenced before it is defined in the JSON) could produce a structurally inconsistent world that passes `WorldImportResult.ok` but fails a subsequent structural validator. This is the highest-risk path.
- **`LLMGenerationAdapter` fallback**: when the provider raises, the adapter swallows the exception and returns the original context unchanged. Ensure callers that need to detect provider failure check `GenerationResult.diagnostics` rather than treating a successful return as proof the LLM ran.
- **`GoalAdmissibilityChecker` in `propagate_admissibility_constraints`**: the rule reads `ctx.constraint_declarations` to narrow admissible ranges. Verify the checker is called with the actor's perceived state, not ontological state — otherwise it violates A-10.

---

## Tests

| Test file | What it covers |
|---|---|
| io | `world_to_json` / `world_to_yaml` round-trip; `WorldImportResult` error paths; LLM view epistemic layer separation; determinism of export output. |
| `test_context_builder.py` | 5 tests — each concrete builder produces a valid model object; `copy_with` immutability; placement instruction respected in `WorldContextualBuilder`. |
| `test_rule_engine.py` | 27 tests — rule application order; constraint propagation correctness for temporal, spatial, admissibility rules; `RuleRegistry` lookup; `combined_generation_rules` composition. |
| `test_context_pipeline.py` | Pipeline integration: rules applied before build; `GenerationResult` fields populated; optional validation triggered when pipeline is configured with a validator. |
| `test_llm_integration.py` | Adapter fallback on provider exception; adapter no-op when provider returns unchanged context; adapter output fed into pipeline correctly. |